### PR TITLE
feat: ReproducibilityGate — lock all RNG sources before training (resolves C-42)

### DIFF
--- a/tests/test_reproducibility_gate.py
+++ b/tests/test_reproducibility_gate.py
@@ -1,0 +1,144 @@
+"""
+TDD tests for ReproducibilityGate — entropy locking and seed control.
+
+C-42: HydraNet has no lock_entropy() — CUDA seeds uncontrolled, Python
+random.seed() not called. Results silently differ across environments.
+
+The gate should:
+1. Lock all 4 RNG sources (random, numpy, torch, torch.cuda)
+2. Be callable before training starts
+3. Produce deterministic results across calls with the same seed
+"""
+
+import random
+
+import numpy as np
+import torch
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 1: Module exists
+# ---------------------------------------------------------------------------
+def test_reproducibility_gate_importable():
+    """ReproducibilityGate must exist in views_hydranet.infrastructure."""
+    from views_hydranet.infrastructure.reproducibility_gate import (  # noqa: F401
+        ReproducibilityGate,
+    )
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 2: lock_entropy method exists
+# ---------------------------------------------------------------------------
+def test_lock_entropy_exists():
+    """ReproducibilityGate must have a lock_entropy static method."""
+    from views_hydranet.infrastructure.reproducibility_gate import (
+        ReproducibilityGate,
+    )
+
+    assert hasattr(ReproducibilityGate, "lock_entropy")
+    assert callable(ReproducibilityGate.lock_entropy)
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 3: lock_entropy resets Python random
+# ---------------------------------------------------------------------------
+def test_lock_entropy_resets_python_random():
+    """After lock_entropy(42), Python's random produces deterministic values."""
+    from views_hydranet.infrastructure.reproducibility_gate import (
+        ReproducibilityGate,
+    )
+
+    ReproducibilityGate.lock_entropy(42)
+    a = [random.random() for _ in range(5)]
+
+    ReproducibilityGate.lock_entropy(42)
+    b = [random.random() for _ in range(5)]
+
+    assert a == b, "Python random not deterministic after lock_entropy"
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 4: lock_entropy resets numpy random
+# ---------------------------------------------------------------------------
+def test_lock_entropy_resets_numpy_random():
+    """After lock_entropy(42), numpy produces deterministic values."""
+    from views_hydranet.infrastructure.reproducibility_gate import (
+        ReproducibilityGate,
+    )
+
+    ReproducibilityGate.lock_entropy(42)
+    a = np.random.rand(5).tolist()
+
+    ReproducibilityGate.lock_entropy(42)
+    b = np.random.rand(5).tolist()
+
+    assert a == b, "NumPy random not deterministic after lock_entropy"
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 5: lock_entropy resets torch random
+# ---------------------------------------------------------------------------
+def test_lock_entropy_resets_torch_random():
+    """After lock_entropy(42), torch produces deterministic values."""
+    from views_hydranet.infrastructure.reproducibility_gate import (
+        ReproducibilityGate,
+    )
+
+    ReproducibilityGate.lock_entropy(42)
+    a = torch.randn(5).tolist()
+
+    ReproducibilityGate.lock_entropy(42)
+    b = torch.randn(5).tolist()
+
+    assert a == b, "PyTorch random not deterministic after lock_entropy"
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 6: training_engine uses lock_entropy instead of manual seeds
+# ---------------------------------------------------------------------------
+def test_training_engine_uses_lock_entropy():
+    """
+    training_engine.training_loop() must call lock_entropy rather than
+    setting seeds manually. Verify by checking source code — the manual
+    np.random.seed / torch.manual_seed calls should be replaced.
+    """
+    import importlib
+    import sys
+
+    mod_name = "views_hydranet.train.training_engine"
+    if mod_name in sys.modules:
+        del sys.modules[mod_name]
+
+    mod = importlib.import_module(mod_name)
+    source = open(mod.__file__).read()
+
+    # Should NOT have manual seed calls
+    assert "np.random.seed(" not in source, (
+        "training_engine.py still uses np.random.seed() instead of lock_entropy()"
+    )
+    assert "torch.manual_seed(" not in source, (
+        "training_engine.py still uses torch.manual_seed() instead of lock_entropy()"
+    )
+
+    # Should import and use lock_entropy
+    assert "lock_entropy" in source, (
+        "training_engine.py does not reference lock_entropy"
+    )
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 7: Different seeds produce different results
+# ---------------------------------------------------------------------------
+def test_different_seeds_produce_different_results():
+    """Sanity check: different seeds must produce different random sequences."""
+    from views_hydranet.infrastructure.reproducibility_gate import (
+        ReproducibilityGate,
+    )
+
+    ReproducibilityGate.lock_entropy(42)
+    a = torch.randn(10).tolist()
+
+    ReproducibilityGate.lock_entropy(99)
+    b = torch.randn(10).tolist()
+
+    assert a != b, "Different seeds produced identical results"

--- a/views_hydranet/infrastructure/reproducibility_gate.py
+++ b/views_hydranet/infrastructure/reproducibility_gate.py
@@ -1,0 +1,61 @@
+"""
+Reproducibility Gate for HydraNet Training.
+
+Ensures bit-reproducible training by locking all sources of randomness
+before training begins. Modeled after the views-r2darts2
+ReproducibilityGate pattern.
+
+Four RNG sources must be locked for reproducible PyTorch training:
+1. Python's random module (used by data loading, augmentation)
+2. NumPy's random (used by VolumeSampler, CurriculumLearner)
+3. PyTorch CPU (used by weight initialization, dropout)
+4. PyTorch CUDA (used by GPU operations, cuDNN)
+
+Without locking all four, identical configs produce different models
+on different hardware or across runs — violating the scientific
+reproducibility contract for conflict forecasting.
+
+See: C-42 in the technical risk register.
+"""
+
+import logging
+import random
+
+import numpy as np
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class ReproducibilityGate:
+    """
+    Entropy control for deterministic training.
+
+    Usage:
+        ReproducibilityGate.lock_entropy(config["np_seed"])
+        # ... then call training_loop()
+    """
+
+    @staticmethod
+    def lock_entropy(np_seed: int, torch_seed: int | None = None) -> None:
+        """
+        Force-reset all RNG seeds to guarantee deterministic training.
+
+        Locks Python random, NumPy, PyTorch CPU, and PyTorch CUDA.
+        Must be called before any training or inference that requires
+        reproducibility.
+
+        Args:
+            np_seed: Seed for Python random and NumPy.
+            torch_seed: Seed for PyTorch CPU and CUDA. If None, uses np_seed.
+        """
+        if torch_seed is None:
+            torch_seed = np_seed
+        random.seed(np_seed)
+        np.random.seed(np_seed)
+        torch.manual_seed(torch_seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(torch_seed)
+        logger.info(
+            f"Entropy locked: numpy/random seed={np_seed}, torch seed={torch_seed}"
+        )

--- a/views_hydranet/train/training_engine.py
+++ b/views_hydranet/train/training_engine.py
@@ -20,6 +20,7 @@ import torch
 import torch.nn as nn
 from tqdm import tqdm
 
+from views_hydranet.infrastructure.reproducibility_gate import ReproducibilityGate
 from views_hydranet.utils.curriculum import CurriculumLearner
 from views_hydranet.utils.integrity_guardian import IntegrityGuardian
 from views_hydranet.utils.training_forensics import TrainingForensics
@@ -305,8 +306,9 @@ def training_loop(
     """
     criterion_reg, criterion_class, multitaskloss_instance = criterion
 
-    np.random.seed(config["np_seed"])
-    torch.manual_seed(config["torch_seed"])
+    ReproducibilityGate.lock_entropy(
+        np_seed=config["np_seed"], torch_seed=config["torch_seed"]
+    )
     logger.info("🚀 Training initiated...")
 
     # Initialize Visual Truth Engine with Authoritative Timestamp


### PR DESCRIPTION
## Summary

Adds `ReproducibilityGate.lock_entropy()` that locks all 4 RNG sources before training starts, replacing the manual seed calls in `training_engine.py`.

### The problem (C-42, Tier 2)
- Only `np.random.seed()` and `torch.manual_seed()` were called — Python `random` and `torch.cuda` were uncontrolled
- Seeds were set inside `training_loop()` rather than at the infrastructure level
- Identical configs could produce different models across environments with no error signal

### The fix
- New module: `views_hydranet/infrastructure/reproducibility_gate.py`
- `ReproducibilityGate.lock_entropy(np_seed, torch_seed)` locks: Python random, NumPy, PyTorch CPU, PyTorch CUDA
- `training_engine.py` imports at top level and delegates to `lock_entropy()`
- Accepts separate `np_seed` and `torch_seed` (backward compatible with existing configs)

### Pattern
Modeled after `views-r2darts2/infrastructure/reproducibility_gate.py` `lock_entropy()`.

## Test plan
- [x] `ruff check .` clean
- [x] 81 tests passing (7 new)
- [x] Tests verify determinism for all 3 RNG sources (random, numpy, torch)
- [x] Test verifies `training_engine.py` no longer contains manual seed calls
- [x] `/review-diff` findings addressed (top-level import, dual seed support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)