### PR TITLE
feat: audit_manifest genome validation before training (resolves C-43)

### DIFF
--- a/tests/test_genome_audit.py
+++ b/tests/test_genome_audit.py
@@ -1,0 +1,215 @@
+"""
+TDD tests for ReproducibilityGate.audit_manifest — parameter genome audit.
+
+C-43: No parameter genome audit before training. A config can omit
+hyperparameters and silently use defaults. The audit should fail-fast
+with a clear error listing missing parameters.
+"""
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 1: audit_manifest method exists
+# ---------------------------------------------------------------------------
+def test_audit_manifest_exists():
+    from views_hydranet.infrastructure.reproducibility_gate import (
+        ReproducibilityGate,
+    )
+
+    assert hasattr(ReproducibilityGate, "audit_manifest")
+    assert callable(ReproducibilityGate.audit_manifest)
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 2: Valid config passes audit
+# ---------------------------------------------------------------------------
+def test_valid_config_passes_audit():
+    """A complete config should pass without error."""
+    from views_hydranet.infrastructure.reproducibility_gate import (
+        ReproducibilityGate,
+    )
+
+    config = {
+        "np_seed": 42,
+        "torch_seed": 42,
+        "learning_rate": 0.001,
+        "weight_decay": 0.0,
+        "total_lessons": 10,
+        "windows_per_lesson": 3,
+        "window_dim": 8,
+        "steps": [1, 2, 3],
+        "time_steps": 3,
+        "clip_grad_norm": True,
+        "input_channels": 3,
+        "output_channels": 1,
+        "total_hidden_channels": 8,
+        "dropout_rate": 0.1,
+        "loss_reg": "mse",
+        "loss_class": "bce",
+    }
+
+    # Should not raise
+    ReproducibilityGate.audit_manifest(config)
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 3: Missing core param raises
+# ---------------------------------------------------------------------------
+def test_missing_core_param_raises():
+    """Config missing a core parameter must raise with clear message."""
+    from views_hydranet.infrastructure.reproducibility_gate import (
+        ReproducibilityGate,
+    )
+
+    config = {
+        # "np_seed" deliberately missing
+        "torch_seed": 42,
+        "learning_rate": 0.001,
+        "weight_decay": 0.0,
+        "total_lessons": 10,
+        "windows_per_lesson": 3,
+        "window_dim": 8,
+        "steps": [1, 2, 3],
+        "time_steps": 3,
+        "clip_grad_norm": True,
+        "input_channels": 3,
+        "output_channels": 1,
+        "total_hidden_channels": 8,
+        "dropout_rate": 0.1,
+        "loss_reg": "mse",
+        "loss_class": "bce",
+    }
+
+    with pytest.raises(ValueError, match="np_seed"):
+        ReproducibilityGate.audit_manifest(config)
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 4: Missing loss-specific param raises
+# ---------------------------------------------------------------------------
+def test_missing_loss_specific_param_raises():
+    """Config with loss_reg='shrinkage' but missing loss_reg_a must raise."""
+    from views_hydranet.infrastructure.reproducibility_gate import (
+        ReproducibilityGate,
+    )
+
+    config = {
+        "np_seed": 42,
+        "torch_seed": 42,
+        "learning_rate": 0.001,
+        "weight_decay": 0.0,
+        "total_lessons": 10,
+        "windows_per_lesson": 3,
+        "window_dim": 8,
+        "steps": [1, 2, 3],
+        "time_steps": 3,
+        "clip_grad_norm": True,
+        "input_channels": 3,
+        "output_channels": 1,
+        "total_hidden_channels": 8,
+        "dropout_rate": 0.1,
+        "loss_reg": "shrinkage",
+        # loss_reg_a deliberately missing
+        "loss_reg_c": 0.001,
+        "loss_class": "bce",
+    }
+
+    with pytest.raises(ValueError, match="loss_reg_a"):
+        ReproducibilityGate.audit_manifest(config)
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 5: Unknown loss name raises
+# ---------------------------------------------------------------------------
+def test_unknown_loss_name_raises():
+    """Config with unregistered loss_reg value must raise."""
+    from views_hydranet.infrastructure.reproducibility_gate import (
+        ReproducibilityGate,
+    )
+
+    config = {
+        "np_seed": 42,
+        "torch_seed": 42,
+        "learning_rate": 0.001,
+        "weight_decay": 0.0,
+        "total_lessons": 10,
+        "windows_per_lesson": 3,
+        "window_dim": 8,
+        "steps": [1, 2, 3],
+        "time_steps": 3,
+        "clip_grad_norm": True,
+        "input_channels": 3,
+        "output_channels": 1,
+        "total_hidden_channels": 8,
+        "dropout_rate": 0.1,
+        "loss_reg": "nonexistent_loss",
+        "loss_class": "bce",
+    }
+
+    with pytest.raises(ValueError, match="nonexistent_loss"):
+        ReproducibilityGate.audit_manifest(config)
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 6: None value in required param raises
+# ---------------------------------------------------------------------------
+def test_none_value_in_required_param_raises():
+    """A core param set to None must fail — implicit defaults are forbidden."""
+    from views_hydranet.infrastructure.reproducibility_gate import (
+        ReproducibilityGate,
+    )
+
+    config = {
+        "np_seed": None,  # present but None
+        "torch_seed": 42,
+        "learning_rate": 0.001,
+        "weight_decay": 0.0,
+        "total_lessons": 10,
+        "windows_per_lesson": 3,
+        "window_dim": 8,
+        "steps": [1, 2, 3],
+        "time_steps": 3,
+        "clip_grad_norm": True,
+        "input_channels": 3,
+        "output_channels": 1,
+        "total_hidden_channels": 8,
+        "dropout_rate": 0.1,
+        "loss_reg": "mse",
+        "loss_class": "bce",
+    }
+
+    with pytest.raises(ValueError, match="np_seed"):
+        ReproducibilityGate.audit_manifest(config)
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 7: loss_reg='mse' with no extra params passes
+# ---------------------------------------------------------------------------
+def test_mse_needs_no_extra_params():
+    """MSE has empty params list — no loss-specific params required."""
+    from views_hydranet.infrastructure.reproducibility_gate import (
+        ReproducibilityGate,
+    )
+
+    config = {
+        "np_seed": 42,
+        "torch_seed": 42,
+        "learning_rate": 0.001,
+        "weight_decay": 0.0,
+        "total_lessons": 10,
+        "windows_per_lesson": 3,
+        "window_dim": 8,
+        "steps": [1, 2, 3],
+        "time_steps": 3,
+        "clip_grad_norm": True,
+        "input_channels": 3,
+        "output_channels": 1,
+        "total_hidden_channels": 8,
+        "dropout_rate": 0.1,
+        "loss_reg": "mse",
+        "loss_class": "bce",
+    }
+
+    # Should not raise
+    ReproducibilityGate.audit_manifest(config)

--- a/views_hydranet/infrastructure/reproducibility_gate.py
+++ b/views_hydranet/infrastructure/reproducibility_gate.py
@@ -1,39 +1,56 @@
 """
 Reproducibility Gate for HydraNet Training.
 
-Ensures bit-reproducible training by locking all sources of randomness
-before training begins. Modeled after the views-r2darts2
-ReproducibilityGate pattern.
+Two responsibilities:
+1. lock_entropy(): Lock all RNG sources before training (C-42)
+2. audit_manifest(): Validate config completeness before training (C-43)
 
-Four RNG sources must be locked for reproducible PyTorch training:
-1. Python's random module (used by data loading, augmentation)
-2. NumPy's random (used by VolumeSampler, CurriculumLearner)
-3. PyTorch CPU (used by weight initialization, dropout)
-4. PyTorch CUDA (used by GPU operations, cuDNN)
+Modeled after the views-r2darts2 ReproducibilityGate pattern.
 
-Without locking all four, identical configs produce different models
-on different hardware or across runs — violating the scientific
-reproducibility contract for conflict forecasting.
-
-See: C-42 in the technical risk register.
+See: C-42, C-43 in the technical risk register.
 """
+
+from __future__ import annotations
 
 import logging
 import random
+from typing import Any, Dict
 
 import numpy as np
 import torch
 
 logger = logging.getLogger(__name__)
 
+# Core genome: parameters every HydraNet config must declare.
+# These are the knobs that affect training outcome.
+CORE_GENOME = [
+    "np_seed",
+    "torch_seed",
+    "learning_rate",
+    "weight_decay",
+    "total_lessons",
+    "windows_per_lesson",
+    "window_dim",
+    "steps",
+    "time_steps",
+    "clip_grad_norm",
+    "input_channels",
+    "output_channels",
+    "total_hidden_channels",
+    "dropout_rate",
+    "loss_reg",
+    "loss_class",
+]
+
 
 class ReproducibilityGate:
     """
-    Entropy control for deterministic training.
+    Entropy control and config validation for deterministic training.
 
     Usage:
-        ReproducibilityGate.lock_entropy(config["np_seed"])
-        # ... then call training_loop()
+        ReproducibilityGate.audit_manifest(config)   # fail-fast on bad config
+        ReproducibilityGate.lock_entropy(...)         # lock RNG
+        training_loop(config, ...)                    # train
     """
 
     @staticmethod
@@ -58,4 +75,80 @@ class ReproducibilityGate:
             torch.cuda.manual_seed_all(torch_seed)
         logger.info(
             f"Entropy locked: numpy/random seed={np_seed}, torch seed={torch_seed}"
+        )
+
+    @staticmethod
+    def audit_manifest(config: Dict[str, Any]) -> None:
+        """
+        Validate config completeness before training.
+
+        Checks:
+        1. All core genome parameters are present and non-None
+        2. The loss_reg and loss_class values are registered
+        3. All loss-specific parameters are present and non-None
+
+        Raises ValueError with a clear message listing missing parameters.
+        Must be called before lock_entropy() and training_loop().
+        """
+        from views_hydranet.utils.utils import LOSS_CLASS_REGISTRY, LOSS_REG_REGISTRY
+
+        # 1. Core genome audit
+        missing_core = [k for k in CORE_GENOME if k not in config]
+        if missing_core:
+            raise ValueError(
+                f"REPRODUCIBILITY CONTRACT VIOLATED: "
+                f"Missing core parameters: {missing_core}"
+            )
+
+        none_core = [k for k in CORE_GENOME if config.get(k) is None]
+        if none_core:
+            raise ValueError(
+                f"REPRODUCIBILITY CONTRACT VIOLATED: "
+                f"Parameters set to None (implicit defaults forbidden): {none_core}"
+            )
+
+        # 2. Loss regression genome
+        loss_reg = config["loss_reg"]
+        if loss_reg not in LOSS_REG_REGISTRY:
+            raise ValueError(
+                f"REPRODUCIBILITY CONTRACT VIOLATED: "
+                f"Unknown regression loss '{loss_reg}'. "
+                f"Registered: {list(LOSS_REG_REGISTRY.keys())}"
+            )
+
+        loss_reg_params = LOSS_REG_REGISTRY[loss_reg]["params"]
+        missing_reg = [k for k in loss_reg_params if k not in config]
+        if missing_reg:
+            raise ValueError(
+                f"REPRODUCIBILITY CONTRACT VIOLATED: "
+                f"Loss '{loss_reg}' requires missing parameters: {missing_reg}"
+            )
+
+        none_reg = [k for k in loss_reg_params if config.get(k) is None]
+        if none_reg:
+            raise ValueError(
+                f"REPRODUCIBILITY CONTRACT VIOLATED: "
+                f"Loss '{loss_reg}' parameters set to None: {none_reg}"
+            )
+
+        # 3. Loss classification genome
+        loss_class = config["loss_class"]
+        if loss_class not in LOSS_CLASS_REGISTRY:
+            raise ValueError(
+                f"REPRODUCIBILITY CONTRACT VIOLATED: "
+                f"Unknown classification loss '{loss_class}'. "
+                f"Registered: {list(LOSS_CLASS_REGISTRY.keys())}"
+            )
+
+        loss_cls_params = LOSS_CLASS_REGISTRY[loss_class]["params"]
+        missing_cls = [k for k in loss_cls_params if k not in config]
+        if missing_cls:
+            raise ValueError(
+                f"REPRODUCIBILITY CONTRACT VIOLATED: "
+                f"Loss '{loss_class}' requires missing parameters: {missing_cls}"
+            )
+
+        logger.info(
+            f"Genome audit passed: {len(CORE_GENOME)} core + "
+            f"{len(loss_reg_params)} loss_reg + {len(loss_cls_params)} loss_class params verified"
         )


### PR DESCRIPTION
## Summary

Adds `ReproducibilityGate.audit_manifest(config)` — validates config completeness before training starts.

### The problem (C-43, Tier 3)
A config could omit `loss_reg_alpha` and silently get default 0.5. The run appears to succeed but uses different hyperparameters than intended. No manifest audit existed.

### The fix
`audit_manifest()` checks three levels:
1. **Core genome (16 params):** seeds, learning rate, architecture dims, loss names — must be present and non-None
2. **Loss regression genome:** params from `LOSS_REG_REGISTRY["params"]` — e.g., `shrinkage` requires `loss_reg_a` + `loss_reg_c`
3. **Loss classification genome:** params from `LOSS_CLASS_REGISTRY["params"]` — e.g., `focal` requires `loss_class_alpha` + `loss_class_gamma`

Unknown loss names and None values are rejected with clear error messages.

### Pattern
Modeled after `views-r2darts2` `ReproducibilityGate.Config.audit_manifest()`.

## Test plan
- [x] `ruff check .` clean
- [x] 88 tests passing (7 new)
- [x] Tests cover: valid config passes, missing core raises, missing loss param raises, unknown loss raises, None value raises

🤖 Generated with [Claude Code](https://claude.com/claude-code)