### PR TITLE
feat: onset head bias initialization for zero-inflated grids (C-44)

### DIFF
--- a/tests/test_onset_bias_init.py
+++ b/tests/test_onset_bias_init.py
@@ -1,0 +1,118 @@
+"""
+TDD tests for classification head bias initialization (C-44).
+
+Autoresearch Finding F1: initializing logit bias to log(event_rate / (1 - event_rate))
+provides 98.5% metric improvement on zero-inflated PRIO-GRID data.
+
+sigmoid(0) = 0.50 (PyTorch default) vs sigmoid(-5) = 0.0067 (correct for ~0.7% event rate).
+"""
+
+import torch
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 1: Classification head biases are set to onset_bias_init value
+# ---------------------------------------------------------------------------
+def test_classification_bias_init_applied():
+    """
+    When onset_bias_init=-5.0, all 3 classification head biases must be -5.0.
+    """
+    from views_hydranet.train.training_engine import make
+
+    config = _make_config(onset_bias_init=-5.0)
+    model, _, _, _ = make(config, torch.device("cpu"))
+
+    for i in range(1, 4):
+        head = getattr(model, f"dec_conv4_head{i}_class")
+        assert head.bias is not None, f"Head {i} has no bias"
+        bias_val = head.bias.data.mean().item()
+        assert abs(bias_val - (-5.0)) < 1e-6, (
+            f"Classification head {i} bias = {bias_val:.4f}, expected -5.0"
+        )
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 2: Regression head biases are NOT affected
+# ---------------------------------------------------------------------------
+def test_regression_bias_not_affected():
+    """
+    Regression head biases must NOT be set to the onset_bias_init value.
+    They should remain at their weight-init default (not -5.0).
+    """
+    from views_hydranet.train.training_engine import make
+
+    config = _make_config(onset_bias_init=-5.0)
+    model, _, _, _ = make(config, torch.device("cpu"))
+
+    for i in range(1, 4):
+        head = getattr(model, f"dec_conv4_head{i}_reg")
+        if head.bias is not None:
+            bias_val = head.bias.data.mean().item()
+            assert abs(bias_val - (-5.0)) > 0.1, (
+                f"Regression head {i} bias = {bias_val:.4f} — should NOT be -5.0"
+            )
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 3: onset_bias_init=None means no custom initialization
+# ---------------------------------------------------------------------------
+def test_none_means_no_custom_init():
+    """
+    When onset_bias_init is None (default), classification head biases
+    should remain at PyTorch defaults (near zero, not -5.0).
+    """
+    from views_hydranet.train.training_engine import make
+
+    config = _make_config(onset_bias_init=None)
+    model, _, _, _ = make(config, torch.device("cpu"))
+
+    for i in range(1, 4):
+        head = getattr(model, f"dec_conv4_head{i}_class")
+        if head.bias is not None:
+            bias_val = head.bias.data.mean().item()
+            assert abs(bias_val) < 1.0, (
+                f"Classification head {i} bias = {bias_val:.4f} — "
+                f"with onset_bias_init=None, should be near zero (PyTorch default)"
+            )
+
+
+# ---------------------------------------------------------------------------
+# RED TEST 4: Different bias values work
+# ---------------------------------------------------------------------------
+def test_custom_bias_value():
+    """onset_bias_init=-3.0 should set biases to -3.0."""
+    from views_hydranet.train.training_engine import make
+
+    config = _make_config(onset_bias_init=-3.0)
+    model, _, _, _ = make(config, torch.device("cpu"))
+
+    head = getattr(model, "dec_conv4_head1_class")
+    bias_val = head.bias.data.mean().item()
+    assert abs(bias_val - (-3.0)) < 1e-6, (
+        f"Classification head bias = {bias_val:.4f}, expected -3.0"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+def _make_config(**overrides):
+    """Minimal config for make() with optional overrides."""
+    config = {
+        "model": "HydraBNUNet06_LSTM4",
+        "input_channels": 3,
+        "output_channels": 1,
+        "total_hidden_channels": 8,
+        "dropout_rate": 0.0,
+        "weight_init": "xavier_uni",
+        "loss_reg": "mse",
+        "loss_class": "bce",
+        "learning_rate": 1e-3,
+        "weight_decay": 0.0,
+        "scheduler": "none",
+        "regression_targets": ["lr_sb_best", "lr_ns_best", "lr_os_best"],
+        "classification_targets": [],
+        "features": ["lr_sb_best", "lr_ns_best", "lr_os_best"],
+    }
+    config.update(overrides)
+    return config

--- a/tests/test_onset_bias_init.py
+++ b/tests/test_onset_bias_init.py
@@ -94,6 +94,59 @@ def test_custom_bias_value():
 
 
 # ---------------------------------------------------------------------------
+# RED TEST 5: Training smoke test with onset_bias_init
+# ---------------------------------------------------------------------------
+def test_training_runs_with_onset_bias():
+    """
+    Full training_loop must complete successfully with onset_bias_init=-5.0.
+    Verifies no interaction bugs between bias init and the training pipeline.
+    """
+    import numpy as np
+
+    from views_hydranet.train.training_engine import make, training_loop
+    from views_hydranet.utils.volume_handler import VolumeHandler
+
+    T, H, W = 6, 8, 8
+    features = ["lr_sb_best", "lr_ns_best", "lr_os_best"]
+    identity = ["month_id", "priogrid_gid"]
+    channel_map = identity + features
+
+    rng = np.random.RandomState(42)
+    data = rng.rand(T, H, W, len(channel_map)).astype(np.float32)
+    for t in range(T):
+        data[t, :, :, 0] = 500 + t
+    for r in range(H):
+        for c in range(W):
+            data[:, r, c, 1] = 1 + r * W + c
+
+    handler = VolumeHandler(
+        data=data, axes=("T", "H", "W", "C"), channel_map=channel_map,
+        time_col="month_id", id_col="priogrid_gid", spatial_cols=("row", "col"),
+        identity_cols=tuple(identity), feature_cols=tuple(features),
+    )
+
+    config = _make_config(
+        onset_bias_init=-5.0,
+        np_seed=42, torch_seed=42, total_lessons=2,
+        windows_per_lesson=1, window_dim=8, steps=[1, 2],
+        time_steps=2, clip_grad_norm=True, random_flips=False,
+        diagnostic_visualizations=False, min_events=1,
+        min_ratio=0.0, max_ratio=1.0, slope_ratio=0.5, roof_ratio=1.0,
+        transformations={"identity": features}, derivations={},
+        time_col="month_id", id_col="priogrid_gid",
+        identity_cols=identity, spatial_cols=["row", "col"],
+    )
+
+    device = torch.device("cpu")
+    model, criterion, optimizer, scheduler = make(config, device)
+    summary = training_loop(
+        config, model, criterion, optimizer, scheduler, handler, device,
+    )
+
+    assert len(summary["loss_history"]) > 0, "No losses recorded"
+
+
+# ---------------------------------------------------------------------------
 # Helper
 # ---------------------------------------------------------------------------
 def _make_config(**overrides):

--- a/views_hydranet/train/training_engine.py
+++ b/views_hydranet/train/training_engine.py
@@ -39,6 +39,34 @@ from views_hydranet.utils.volume_sampler import VolumeSampler
 logger = logging.getLogger(__name__)
 
 
+def _init_classification_head_bias(model: nn.Module, bias_value: float) -> None:
+    """
+    Initialize classification decoder head biases to logit(event_rate).
+
+    Autoresearch Finding F1: sigmoid(0) = 0.50 is a 25-71x overestimate of
+    the true event rate on zero-inflated PRIO-GRID data. Initializing to
+    logit(event_rate) provides 98.5% metric improvement.
+
+    Targets layers named 'dec_conv4_head{N}_class' — the final output
+    Conv2d of each classification decoder branch.
+    """
+    count = 0
+    for name, module in model.named_modules():
+        is_class_head = "dec_conv4" in name and "_class" in name
+        has_bias = hasattr(module, "bias") and module.bias is not None
+        if is_class_head and has_bias:
+            nn.init.constant_(module.bias, bias_value)
+            count += 1
+            logger.debug(f"Classification head '{name}' bias → {bias_value:.2f}")
+    import math
+
+    sigmoid_val = 1.0 / (1.0 + math.exp(-bias_value))
+    logger.info(
+        f"Onset bias initialization: {count} classification heads set to {bias_value:.2f} "
+        f"(sigmoid = {sigmoid_val:.4f}, i.e. {sigmoid_val*100:.2f}% prior event probability)"
+    )
+
+
 def make(config: dict, device: torch.device):
     model = choose_model(config, device)
 
@@ -47,6 +75,11 @@ def make(config: dict, device: torch.device):
 
     # Apply the initialization function to the model
     model.apply(init_fn)
+
+    # Classification head bias initialization (C-44)
+    onset_bias = config.get("onset_bias_init")
+    if onset_bias is not None:
+        _init_classification_head_bias(model, onset_bias)
 
     # choose loss function
     criterion = choose_loss(config, device)  # this is a tuple of the reg and the class criteria

--- a/views_hydranet/utils/config_initializer.py
+++ b/views_hydranet/utils/config_initializer.py
@@ -89,6 +89,10 @@ class HydraNetConfig(BaseModel):
     # FocalLoss params (loss_class='focal')
     loss_class_gamma: float = Field(default=1.5)
     loss_class_alpha: float = Field(default=0.75)
+    # Classification head bias initialization (C-44)
+    # Set to log(event_rate / (1 - event_rate)). None = PyTorch default.
+    # -5.0 ≈ 0.67% event rate, -7.0 ≈ 0.09% event rate.
+    onset_bias_init: float | None = Field(default=None)
 
     # 7. Sampling & Reproducibility
     total_lessons: int = Field(..., ge=1)


### PR DESCRIPTION
## Summary

Initializes classification decoder head biases to `log(event_rate / (1 - event_rate))` instead of PyTorch default (~0).

### The problem (C-44, Tier 2)
`sigmoid(0) = 0.50` — the model starts predicting 50% event probability on a grid where the true rate is 0.7-3%. BCE loss wastes training capacity on the trivial fact that "most cells are peaceful" instead of learning which cells are escalating.

### The evidence
Metric-lab autoresearch (45 experiments): **98.5% metric improvement** from `nn.init.constant_(bias, -5.0)`. The single most impactful intervention found.

### The fix
- `_init_classification_head_bias(model, bias_value)` targets `dec_conv4_head{N}_class` layers via `named_modules()` after weight init
- New config parameter: `onset_bias_init` (None = PyTorch default, -5.0 = ~0.67% prior)
- Called from `make()` in `training_engine.py` — separation of concerns (architecture defines structure, pipeline configures initialization)

### Design decision
Option C from plan: initialize after `model.apply()` using `named_modules()` to identify classification heads by name. The architecture doesn't need to know about event rates. The config controls the prior.

## Test plan
- [x] `ruff check .` clean
- [x] 65 tests passing (4 new)
- [x] `test_classification_bias_init_applied`: all 3 class heads == -5.0
- [x] `test_regression_bias_not_affected`: reg heads unchanged
- [x] `test_none_means_no_custom_init`: backward compatible
- [x] `test_custom_bias_value`: -3.0 works too
- [x] All 3 views-models configs updated with `onset_bias_init: -5.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)