### PR TITLE
feat: Pareto loss, hurdle masking, QS99 tail regularizer (cluster E)

### DIFF
--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -5,8 +5,8 @@
 | Project           | views-hydranet                       |
 | Owner             | Simon Polichinel von der Maase       |
 | Last Updated      | 2026-04-10                           |
-| Total Concerns    | 47                                   |
-| Open Concerns     | 29                                   |
+| Total Concerns    | 48                                   |
+| Open Concerns     | 30                                   |
 | Resolved Concerns | 18                                   |
 
 ---
@@ -491,6 +491,24 @@ This is architecturally different from a loss function swap. The QS99 term is a 
 This cannot be implemented as a LOSS_REG_REGISTRY entry because it operates on a derived quantity (the predicted quantile), not on the raw prediction-target pair. It requires a training loop change.
 
 Literature: Lerch et al. (2017) [views-metric-lab/lit/scoring_rules/Lerch-ForecastersDilemmaExtreme-2017.pdf], Gneiting & Ranjan (2011) [views-metric-lab/lit/scoring_rules/Gneiting-ComparingDensityForecasts-2011.pdf], Kozerawski & Turk (2022) [views-metric-lab/lit/long_tail/Kozerawski-TamingLongTailDeepProbabilistic-2022.pdf]. See also C-45 (hurdle masking) and C-47 (Pareto loss).
+
+---
+
+### C-49: Flat config schema may not scale — no nested structure for regularizers, strategies, or per-target settings
+
+| Field | Value |
+|-------|-------|
+| ID | C-49 |
+| Tier | 4 |
+| Source | manual (2026-04-10) |
+| Trigger | When the number of flat config keys exceeds ~40-50, or when adding a feature requires 3+ related keys that would be cleaner as a nested group |
+| Location | `config_initializer.py` (`HydraNetConfig`), `CORE_GENOME` in `reproducibility_gate.py` |
+
+`HydraNetConfig` uses flat keys for all parameters: `loss_reg_alpha`, `loss_reg_sigma`, `loss_class_gamma`, `qs99_weight`, `qs99_tau`, `hurdle_threshold`, etc. This is consistent, simple, and works well at the current scale (~25 keys). But the pattern has a threshold of inconvenience: as regularizers, per-target settings, and training strategies accumulate, flat keys become ambiguous (does `alpha` belong to the loss, the regularizer, or the curriculum?), hard to group visually in config files, and awkward for the genome audit (which keys belong to which feature?).
+
+The alternative is nested structure: `regularizers: { qs99: { weight: 0.01, tau: 0.99 } }`. This is cleaner for extensibility but breaks the flat-key pattern, complicates Pydantic validation, and requires changes to the genome audit.
+
+Current decision: stay flat. Revisit when either (a) total config keys exceed 50, or (b) a feature requires 4+ related keys that create naming collision risk. The migration is mechanical (rename keys, update configs) but touches every model config in views-models.
 
 ---
 

--- a/tests/test_cluster_e.py
+++ b/tests/test_cluster_e.py
@@ -1,0 +1,287 @@
+"""
+Tests for Cluster E: Loss/training science (C-45, C-47, C-48).
+
+C-47: ParetoLoss in registry
+C-45: Hurdle masking in _process_sequence
+C-48: QS99 tail regularizer (distribution-free pinball)
+"""
+
+import torch
+
+
+# ---------------------------------------------------------------------------
+# C-47: ParetoLoss
+# ---------------------------------------------------------------------------
+def test_pareto_loss_importable():
+    from views_hydranet.utils.pareto_loss import ParetoLoss  # noqa: F401
+
+
+def test_pareto_loss_is_nn_module():
+    from views_hydranet.utils.pareto_loss import ParetoLoss
+
+    assert isinstance(ParetoLoss(alpha=1.0), torch.nn.Module)
+
+
+def test_pareto_loss_forward_returns_scalar():
+    from views_hydranet.utils.pareto_loss import ParetoLoss
+
+    loss_fn = ParetoLoss(alpha=1.0)
+    pred = torch.randn(1, 4, 4, requires_grad=True)
+    target = torch.randn(1, 4, 4)
+    result = loss_fn(pred, target)
+    assert result.ndim == 0
+    assert result.requires_grad
+    assert result >= 0, f"Pareto loss should be non-negative, got {result.item()}"
+
+
+def test_pareto_loss_registered_in_choose_loss():
+    from views_hydranet.utils.pareto_loss import ParetoLoss
+    from views_hydranet.utils.utils import choose_loss
+
+    config = {
+        "loss_reg": "pareto",
+        "loss_reg_pareto_alpha": 1.0,
+        "loss_class": "bce",
+        "regression_targets": ["lr_sb_best"],
+        "classification_targets": [],
+    }
+    criterion_reg, _, _ = choose_loss(config, torch.device("cpu"))
+    assert isinstance(criterion_reg, ParetoLoss)
+
+
+def test_pareto_loss_gradient_between_l1_and_mse():
+    """
+    Pareto gradient should be smaller than MSE but larger than zero
+    for large errors — it's sublinear, not quadratic.
+    """
+    from views_hydranet.utils.pareto_loss import ParetoLoss
+
+    pred = torch.zeros(1, 4, 4, requires_grad=True)
+    target = torch.zeros(1, 4, 4)
+    target[0, 0, 0] = 100.0
+
+    ParetoLoss(alpha=1.0)(pred, target).backward()
+    grad_pareto = pred.grad[0, 0, 0].abs().item()
+    pred.grad = None
+
+    torch.nn.MSELoss()(pred, target).backward()
+    grad_mse = pred.grad[0, 0, 0].abs().item()
+
+    assert grad_pareto < grad_mse, (
+        f"Pareto gradient ({grad_pareto}) should be < MSE ({grad_mse}) for outliers"
+    )
+    assert grad_pareto > 0, "Pareto gradient should be > 0"
+
+
+# ---------------------------------------------------------------------------
+# C-45: Hurdle masking
+# ---------------------------------------------------------------------------
+def test_hurdle_masking_reduces_loss_contributors():
+    """
+    With hurdle_threshold=0.0, regression loss should only come from
+    positive target values. A tensor with all zeros should produce
+    zero regression loss.
+    """
+    from views_hydranet.train.training_engine import _process_sequence, _SequenceIndices
+
+    B, T, C, H, W = 1, 3, 1, 4, 4
+    # All zeros — with hurdle masking, regression loss should be 0
+    train_tensor = torch.zeros(B, T, C, H, W)
+    h = torch.zeros(B, 8, H, W)
+
+    model = _make_tiny_model()
+    idx = _SequenceIndices(["feat"], {"regression_targets": ["feat"],
+                                       "classification_targets": [],
+                                       "features": ["feat"]})
+
+    result = _process_sequence(
+        train_tensor, model, h,
+        torch.nn.MSELoss(), torch.nn.BCELoss(), _SumReducer(),
+        idx, torch.device("cpu"),
+        hurdle_threshold=0.0,
+    )
+
+    # With all-zero targets and hurdle masking, no positive pixels exist
+    # so regression loss should be 0
+    reg_loss = result["reg"].item()
+    assert reg_loss == 0.0, (
+        f"Regression loss should be 0 with all-zero targets and hurdle, got {reg_loss}"
+    )
+
+
+def test_hurdle_none_processes_all_pixels():
+    """
+    With hurdle_threshold=None (default), all pixels contribute to loss.
+    Even all-zero targets should produce non-zero regression loss
+    (because predictions are non-zero).
+    """
+    from views_hydranet.train.training_engine import _process_sequence, _SequenceIndices
+
+    B, T, C, H, W = 1, 3, 1, 4, 4
+    train_tensor = torch.zeros(B, T, C, H, W)
+    h = torch.zeros(B, 8, H, W)
+
+    model = _make_tiny_model()
+    idx = _SequenceIndices(["feat"], {"regression_targets": ["feat"],
+                                       "classification_targets": [],
+                                       "features": ["feat"]})
+
+    result = _process_sequence(
+        train_tensor, model, h,
+        torch.nn.MSELoss(), torch.nn.BCELoss(), _SumReducer(),
+        idx, torch.device("cpu"),
+        hurdle_threshold=None,
+    )
+
+    # Without hurdle, predictions on zero targets still produce non-zero MSE
+    total = result["total"].item()
+    assert total > 0, f"Without hurdle, loss should be > 0 even for zero targets, got {total}"
+
+
+# ---------------------------------------------------------------------------
+# C-48: QS99 regularizer
+# ---------------------------------------------------------------------------
+def test_qs99_regularizer_adds_to_loss():
+    """
+    With qs99_weight > 0 and hurdle enabled, the total loss should differ
+    from the case without the regularizer.
+    """
+    from views_hydranet.train.training_engine import _process_sequence, _SequenceIndices
+
+    B, T, C, H, W = 1, 3, 1, 4, 4
+    train_tensor = torch.randn(B, T, C, H, W).abs()  # positive values
+    h = torch.zeros(B, 8, H, W)
+
+    model = _make_tiny_model()
+    idx = _SequenceIndices(["feat"], {"regression_targets": ["feat"],
+                                       "classification_targets": [],
+                                       "features": ["feat"]})
+
+    # Without regularizer
+    result_no_qs = _process_sequence(
+        train_tensor, model, h.clone(),
+        torch.nn.MSELoss(), torch.nn.BCELoss(), _SumReducer(),
+        idx, torch.device("cpu"),
+        hurdle_threshold=0.0, qs99_weight=0.0,
+    )
+
+    # With regularizer
+    result_with_qs = _process_sequence(
+        train_tensor, model, h.clone(),
+        torch.nn.MSELoss(), torch.nn.BCELoss(), _SumReducer(),
+        idx, torch.device("cpu"),
+        hurdle_threshold=0.0, qs99_weight=0.1, qs99_tau=0.99,
+    )
+
+    loss_no = result_no_qs["total"].item()
+    loss_with = result_with_qs["total"].item()
+    assert loss_no != loss_with, (
+        f"QS99 regularizer should change the total loss: "
+        f"without={loss_no}, with={loss_with}"
+    )
+
+
+def test_qs99_disabled_when_no_hurdle():
+    """QS99 weight > 0 but hurdle_threshold=None should NOT add regularizer."""
+    from views_hydranet.train.training_engine import _process_sequence, _SequenceIndices
+
+    B, T, C, H, W = 1, 3, 1, 4, 4
+    train_tensor = torch.randn(B, T, C, H, W).abs()
+    h = torch.zeros(B, 8, H, W)
+
+    model = _make_tiny_model()
+    idx = _SequenceIndices(["feat"], {"regression_targets": ["feat"],
+                                       "classification_targets": [],
+                                       "features": ["feat"]})
+
+    result_a = _process_sequence(
+        train_tensor, model, h.clone(),
+        torch.nn.MSELoss(), torch.nn.BCELoss(), _SumReducer(),
+        idx, torch.device("cpu"),
+        hurdle_threshold=None, qs99_weight=0.0,
+    )
+
+    result_b = _process_sequence(
+        train_tensor, model, h.clone(),
+        torch.nn.MSELoss(), torch.nn.BCELoss(), _SumReducer(),
+        idx, torch.device("cpu"),
+        hurdle_threshold=None, qs99_weight=0.1,
+    )
+
+    assert abs(result_a["total"].item() - result_b["total"].item()) < 1e-6, (
+        "QS99 should have no effect when hurdle is disabled"
+    )
+
+
+# ---------------------------------------------------------------------------
+# C-45: Hurdle masking with mixed data
+# ---------------------------------------------------------------------------
+def test_hurdle_masking_mixed_data():
+    """
+    With mixed data (some positive, some zero), hurdle masking should
+    produce a different loss than no masking — because the zero-pixel
+    gradients are excluded.
+    """
+    from views_hydranet.train.training_engine import _process_sequence, _SequenceIndices
+
+    B, T, C, H, W = 1, 3, 1, 4, 4
+    train_tensor = torch.zeros(B, T, C, H, W)
+    # Plant a few positive values
+    train_tensor[0, 1, 0, 0, 0] = 5.0
+    train_tensor[0, 2, 0, 0, 0] = 3.0
+    train_tensor[0, 1, 0, 2, 2] = 10.0
+    train_tensor[0, 2, 0, 2, 2] = 7.0
+    h = torch.zeros(B, 8, H, W)
+
+    model = _make_tiny_model()
+    idx = _SequenceIndices(
+        ["feat"],
+        {"regression_targets": ["feat"], "classification_targets": [], "features": ["feat"]},
+    )
+
+    result_no_hurdle = _process_sequence(
+        train_tensor, model, h.clone(),
+        torch.nn.MSELoss(), torch.nn.BCELoss(), _SumReducer(),
+        idx, torch.device("cpu"), hurdle_threshold=None,
+    )
+
+    result_hurdle = _process_sequence(
+        train_tensor, model, h.clone(),
+        torch.nn.MSELoss(), torch.nn.BCELoss(), _SumReducer(),
+        idx, torch.device("cpu"), hurdle_threshold=0.0,
+    )
+
+    loss_no = result_no_hurdle["total"].item()
+    loss_hurdle = result_hurdle["total"].item()
+    assert loss_no != loss_hurdle, (
+        f"Hurdle masking should change loss with mixed data: "
+        f"no_hurdle={loss_no:.6f}, hurdle={loss_hurdle:.6f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+class _SumReducer(torch.nn.Module):
+    """Mock MultiTaskLoss that sums all losses to a scalar."""
+
+    def forward(self, losses):
+        return losses.sum()
+
+
+def _make_tiny_model():
+    """Minimal model that matches HydraNet's forward signature."""
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(1, 1, 1)
+            self.base = 8
+
+        def forward(self, x, h):
+            out = self.conv(x)
+            return out, out, h
+
+        def init_hTtime(self, hidden_channels, H, W):
+            return torch.zeros(1, hidden_channels, H, W)
+
+    return TinyModel()

--- a/views_hydranet/train/training_engine.py
+++ b/views_hydranet/train/training_engine.py
@@ -120,6 +120,9 @@ def _process_sequence(
     device: torch.device,
     pbar: Optional[tqdm] = None,
     forensics: Optional[TrainingForensics] = None,
+    hurdle_threshold: Optional[float] = None,
+    qs99_weight: float = 0.0,
+    qs99_tau: float = 0.99,
 ) -> Dict[str, Any]:
     """
     Pure sequence processing: forward pass over [B, T, C, H, W] tensor.
@@ -163,13 +166,39 @@ def _process_sequence(
 
         # Loss computation
         losses_list = []
+        qs99_loss = torch.tensor(0.0, device=device)
         for j in range(idx.n_reg):
-            losses_list.append(criterion_reg(t1_pred[:, j, :, :], y_reg[:, j, :, :]))
+            pred_j = t1_pred[:, j, :, :]
+            target_j = y_reg[:, j, :, :]
+
+            if hurdle_threshold is not None:
+                # C-45: Regression loss on positive observations only
+                mask = target_j > hurdle_threshold
+                if mask.any():
+                    losses_list.append(criterion_reg(pred_j[mask], target_j[mask]))
+                else:
+                    losses_list.append(torch.tensor(0.0, device=device))
+
+                # C-48: QS99 regularizer (distribution-free pinball on mu)
+                # Only active when hurdle is enabled and weight > 0
+                if qs99_weight > 0 and mask.any():
+                    error = target_j[mask] - pred_j[mask]
+                    pinball = torch.where(
+                        error >= 0,
+                        qs99_tau * error,
+                        (qs99_tau - 1.0) * error,
+                    )
+                    qs99_loss = qs99_loss + pinball.mean()
+            else:
+                losses_list.append(criterion_reg(pred_j, target_j))
+
         for j in range(idx.n_cls):
             losses_list.append(criterion_class(t1_pred_class[:, j, :, :], y_cls[:, j, :, :]))
 
         losses = torch.stack(losses_list)
         loss = cast(Any, multitaskloss_instance)(losses)
+        if qs99_weight > 0:
+            loss = loss + qs99_weight * qs99_loss
         total_loss += loss
 
         loss_reg = losses[: idx.n_reg].sum()
@@ -266,6 +295,9 @@ def train(
         train_tensor, model, h,
         criterion_reg, criterion_class, multitaskloss_instance,
         idx, device, pbar=pbar, forensics=forensics,
+        hurdle_threshold=config.get("hurdle_threshold"),
+        qs99_weight=config.get("qs99_weight", 0.0),
+        qs99_tau=config.get("qs99_tau", 0.99),
     )
     step_total, step_reg, step_cls = result["per_step_losses"]
 

--- a/views_hydranet/utils/config_initializer.py
+++ b/views_hydranet/utils/config_initializer.py
@@ -86,13 +86,18 @@ class HydraNetConfig(BaseModel):
     loss_reg_alpha: float = Field(default=0.5)
     # Shared: BasuDPDLoss sigma / LogNormalFixedSigmaLoss sigma
     loss_reg_sigma: float = Field(default=1.0)
+    # ParetoLoss params (loss_reg='pareto')
+    loss_reg_pareto_alpha: float = Field(default=1.0)
     # FocalLoss params (loss_class='focal')
     loss_class_gamma: float = Field(default=1.5)
     loss_class_alpha: float = Field(default=0.75)
     # Classification head bias initialization (C-44)
-    # Set to log(event_rate / (1 - event_rate)). None = PyTorch default.
-    # -5.0 ≈ 0.67% event rate, -7.0 ≈ 0.09% event rate.
     onset_bias_init: float | None = Field(default=None)
+    # Hurdle masking (C-45): None = disabled, 0.0 = standard hurdle (y > 0)
+    hurdle_threshold: float | None = Field(default=None)
+    # QS99 tail regularizer (C-48): 0.0 = disabled. Only active when hurdle is enabled.
+    qs99_weight: float = Field(default=0.0)
+    qs99_tau: float = Field(default=0.99)
 
     # 7. Sampling & Reproducibility
     total_lessons: int = Field(..., ge=1)

--- a/views_hydranet/utils/pareto_loss.py
+++ b/views_hydranet/utils/pareto_loss.py
@@ -1,0 +1,52 @@
+"""
+Pareto Loss for Regression Heads.
+
+Log-transformed error that is approximately linear for small errors and
+sublinear for large errors. Upweights rare high-error samples relative
+to MSE while preventing outlier gradient domination.
+
+    L = (1/alpha) * log(1 + alpha * |target - prediction|)
+
+From Kozerawski & Turk (2022), "Taming the Long Tail in Deep
+Probabilistic Forecasting."
+[views-metric-lab/lit/long_tail/Kozerawski-TamingLongTailDeepProbabilistic-2022.pdf]
+
+Winner of metric-lab autoresearch Round 4 (61 experiments) when combined
+with a QS99 tail regularizer. Without the regularizer, Pareto converges
+to the same performance as Shrinkage and Basu DPD (within 0.04%).
+See: views-metric-lab/reports/experiments/autoresearch_basu_apr09_report.md
+"""
+
+import logging
+
+import torch
+import torch.nn as nn
+
+logger = logging.getLogger(__name__)
+
+
+class ParetoLoss(nn.Module):
+    """
+    Log-transformed absolute error loss.
+
+    L(y, y_hat) = (1/alpha) * log(1 + alpha * |y - y_hat|)
+
+    Parameters
+    ----------
+    alpha : float
+        Controls the transition from linear to sublinear behavior.
+        alpha=1.0: recommended (autoresearch optimal).
+        Smaller alpha: more linear (closer to L1).
+        Larger alpha: more sublinear (stronger outlier compression).
+    """
+
+    def __init__(self, alpha: float = 1.0):
+        super().__init__()
+        if alpha <= 0:
+            raise ValueError(f"alpha must be > 0, got {alpha}")
+        self.alpha = alpha
+        logger.info(f"ParetoLoss initialized: alpha={alpha}")
+
+    def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        diff = torch.abs(target - input)
+        return ((1.0 / self.alpha) * torch.log1p(self.alpha * diff)).mean()

--- a/views_hydranet/utils/utils.py
+++ b/views_hydranet/utils/utils.py
@@ -13,6 +13,7 @@ from views_hydranet.utils.basu_loss import BasuDPDLoss
 from views_hydranet.utils.focal_loss import FocalLoss
 from views_hydranet.utils.lognormal_nll_loss import LogNormalFixedSigmaLoss
 from views_hydranet.utils.mtloss import MultiTaskLoss
+from views_hydranet.utils.pareto_loss import ParetoLoss
 from views_hydranet.utils.shrinkage_loss import ShrinkageLoss
 from views_hydranet.utils.warmup_decay_lr_scheduler import WarmupDecayLearningRateScheduler
 
@@ -65,6 +66,13 @@ LOSS_REG_REGISTRY: Dict[str, Any] = {
         "params": ["loss_reg_sigma"],
         "factory": lambda config, device: LogNormalFixedSigmaLoss(
             sigma=config.get("loss_reg_sigma", 0.9),
+        ).to(device),
+    },
+    "pareto": {
+        "cls": ParetoLoss,
+        "params": ["loss_reg_pareto_alpha"],
+        "factory": lambda config, device: ParetoLoss(
+            alpha=config.get("loss_reg_pareto_alpha", 1.0),
         ).to(device),
     },
 }


### PR DESCRIPTION
## Summary

Three features from metric-lab autoresearch findings, implementing the loss/training science cluster (C-45, C-47, C-48).

### C-47: Pareto Loss
- `ParetoLoss`: `(1/alpha) * log(1 + alpha * |error|)` from Kozerawski et al. (2022)
- Registered as `loss_reg='pareto'` with `loss_reg_pareto_alpha` (default 1.0)
- Gradient profile: linear for small errors, sublinear for large — better than MSE for heavy-tailed data

### C-45: Hurdle Masking
- `hurdle_threshold` config key: `None`=disabled (backward compat), `0.0`=standard hurdle
- Regression loss computed on `target > threshold` pixels only
- Addresses the "Zero-Gravity" effect (Lerch et al. 2017): 97% peace-time gradients no longer drown crisis signal

### C-48: QS99 Tail Regularizer
- Distribution-free asymmetric pinball loss directly on `mu` (no sigma, no distributional assumption)
- `qs99_weight` (0.0=disabled), `qs99_tau` (default 0.99)
- Only active when hurdle is enabled (per design discussion)
- Addresses the Forecaster's Dilemma: CRPS alone systematically discourages sharp tail predictions

### Design decisions
- **Distribution-free QS99** (ML expert Suggestion 3): no fictional sigma injected into a model that never learned one
- **Flat config keys** (not nested regularizers dict): consistent with existing pattern. C-49 registered for future revision.
- **QS99 requires hurdle**: scientifically, the regularizer only makes sense on positive-only pixels

## Test plan
- [x] `ruff check .` clean
- [x] 103 tests passing (10 new)
- [x] Pareto: import, module, scalar, registry, gradient property
- [x] Hurdle: all-zeros masked (loss=0), None bypass, mixed data
- [x] QS99: regularizer changes loss, disabled when no hurdle

🤖 Generated with [Claude Code](https://claude.com/claude-code)