### PR TITLE
fix: add importorskip guards to 12 test files (C-10)

### DIFF
--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -6,8 +6,8 @@
 | Owner             | Simon Polichinel von der Maase       |
 | Last Updated      | 2026-04-10                           |
 | Total Concerns    | 51                                   |
-| Open Concerns     | 25                                   |
-| Resolved Concerns | 26                                   |
+| Open Concerns     | 24                                   |
+| Resolved Concerns | 27                                   |
 
 ---
 
@@ -87,20 +87,6 @@ Additionally, `torch.load(..., weights_only=False)` deserializes arbitrary Pytho
 Per Martin (Clean Architecture Ch 32, p.275-278): "Don't marry the framework." The serialized artifact is married to PyTorch's pickle format and the concrete class path — the tightest possible coupling to a framework detail. `state_dict()` serialization would keep PyTorch at arm's length, making the architecture class freely renameable and movable.
 
 ---
-
-### C-10: 13 test files require views_pipeline_core
-
-| Field | Value |
-|-------|-------|
-| ID | C-10 |
-| Tier | 3 |
-| Source | repo-assimilation (2026-04-08) |
-| Trigger | Developer runs tests in partial environment without pipeline_core |
-| Location | `tests/conftest.py:9`, 13 test files |
-
-Tests covering manager integration, PredictionFrame output, and subset symmetry cannot run without `views_pipeline_core`. The conftest gate (280 minimum) only triggers when running the full suite from `tests/`. In partial environments, 270 tests collect and the gate is bypassed, silently missing integration coverage.
-
-Per Martin (Clean Architecture Ch 28, p.243-246): "Design for Testability" — tests should not depend on volatile things. The test suite's dependence on the framework layer (`views_pipeline_core`) at import time makes 13 test files fragile. Martin's "Testing API" (p.245) principle: decouple test structure from application structure. See also C-27 for the specific import chain that causes this.
 
 ---
 
@@ -672,6 +658,16 @@ See also C-20 (resolved — added the soft warning).
 | ID | C-28 |
 | Resolved | 2026-04-08 |
 | Resolution | Updated test alignment sections in HydranetManager.md, HydraNetConfig.md, and ConfigInitializer.md to reference actual test files (test_config_typed.py, test_config_validation.py, test_manager_memory_hygiene.py, etc.) |
+
+---
+
+### C-10: 12 test files require views_pipeline_core — RESOLVED
+
+| Field | Value |
+|-------|-------|
+| ID | C-10 |
+| Resolved | 2026-04-10 |
+| Resolution | Added `pytest.importorskip("views_pipeline_core")` to 10 test files, `pytest.importorskip("views_evaluation")` to 1 file, and `pytest.importorskip("polars")` to 1 file. Collection errors replaced with clean skip markers. In partial environments: 349 tests collect, 12 skip, 0 errors. In full environments: 414 tests collect, 0 skip. Conftest minimum-test gate (280) continues to function correctly. |
 
 ---
 

--- a/tests/test_audit_manager_eval_survival.py
+++ b/tests/test_audit_manager_eval_survival.py
@@ -4,6 +4,9 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
+
+pytest.importorskip("views_pipeline_core")
+
 from views_pipeline_core.data.prediction_frame import PredictionFrame
 
 from views_hydranet.manager.hydranet_manager import HydranetManager

--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -14,6 +14,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
+pytest.importorskip("views_pipeline_core")
+
 from views_hydranet.utils.data_fetcher import DataFetcher
 
 # ---------------------------------------------------------------------------

--- a/tests/test_data_pipeline_extraction.py
+++ b/tests/test_data_pipeline_extraction.py
@@ -13,6 +13,8 @@ import pandas as pd
 import pytest
 import torch
 
+pytest.importorskip("views_pipeline_core")
+
 from views_hydranet.manager.hydranet_manager import HydranetManager
 
 # ---------------------------------------------------------------------------

--- a/tests/test_eval_integration_toy.py
+++ b/tests/test_eval_integration_toy.py
@@ -1,4 +1,8 @@
 import pandas as pd
+import pytest
+
+pytest.importorskip("views_evaluation")
+
 from views_evaluation.evaluation.evaluation_manager import EvaluationManager
 
 

--- a/tests/test_inference_orchestrator_pf.py
+++ b/tests/test_inference_orchestrator_pf.py
@@ -14,6 +14,9 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
+
+pytest.importorskip("views_pipeline_core")
+
 from views_pipeline_core.data.prediction_frame import PredictionFrame
 
 from views_hydranet.utils.feature_scaler import FeatureScaler

--- a/tests/test_manager_memory_hygiene.py
+++ b/tests/test_manager_memory_hygiene.py
@@ -10,7 +10,10 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import numpy as np
 import pandas as pd
+import pytest
 import torch
+
+pytest.importorskip("views_pipeline_core")
 
 from views_hydranet.manager.hydranet_manager import HydranetManager
 

--- a/tests/test_memory_fingerprint.py
+++ b/tests/test_memory_fingerprint.py
@@ -5,6 +5,10 @@ from typing import Dict, List
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import pytest
+
+pytest.importorskip("polars")
+
 import polars as pl
 import psutil
 

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -5,6 +5,8 @@ import pandas as pd
 import pytest
 import torch
 
+pytest.importorskip("views_pipeline_core")
+
 from views_hydranet.architectures.HydraBNrecurrentUnet_06_LSTM4 import HydraBNUNet06_LSTM4
 from views_hydranet.manager.hydranet_manager import HydranetManager
 

--- a/tests/test_prediction_frame_suite.py
+++ b/tests/test_prediction_frame_suite.py
@@ -29,6 +29,9 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
+
+pytest.importorskip("views_pipeline_core")
+
 from views_pipeline_core.data.prediction_frame import PredictionFrame
 
 from views_hydranet.manager.hydranet_manager import HydranetManager

--- a/tests/test_subset_symmetry.py
+++ b/tests/test_subset_symmetry.py
@@ -4,6 +4,9 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
+
+pytest.importorskip("views_pipeline_core")
+
 from views_pipeline_core.data.prediction_frame import PredictionFrame
 
 from views_hydranet.manager.hydranet_manager import HydranetManager

--- a/tests/test_sweep_and_hardening_gates.py
+++ b/tests/test_sweep_and_hardening_gates.py
@@ -3,6 +3,8 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import pytest
 import torch
 
+pytest.importorskip("views_pipeline_core")
+
 from views_hydranet.manager.hydranet_manager import HydranetManager
 from views_hydranet.train.train_model import train_model_artifact
 

--- a/tests/test_volume_handler_pf.py
+++ b/tests/test_volume_handler_pf.py
@@ -11,6 +11,9 @@ Verifies:
 import numpy as np
 import pandas as pd
 import pytest
+
+pytest.importorskip("views_pipeline_core")
+
 from views_pipeline_core.data.prediction_frame import PredictionFrame
 
 from views_hydranet.utils.volume_handler import VolumeHandler


### PR DESCRIPTION
## Summary

- Add `pytest.importorskip()` guards to 12 test files that require external packages (`views_pipeline_core`, `views_evaluation`, `polars`). Collection errors replaced with clean skip markers.
- Resolve C-10 in the risk register.

## Test plan

- [x] Partial env (no views_pipeline_core): 349 collected, 12 skipped, 0 collection errors
- [x] Full env (conda views-hydranet-env): 412 passed, 0 skipped, 2 expected failures
- [x] Conftest minimum-test gate (280) continues to function
- [x] `ruff check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)