### PR TITLE
fix: sprint C-50, C-22, C-40 — derivation symmetry, ModelOutput, docs portability

### DIFF
--- a/docs/validate_docs.sh
+++ b/docs/validate_docs.sh
@@ -57,7 +57,7 @@ echo "--- Checking cross-ADR references (constitutional: 000-009) ---"
 while IFS= read -r ref; do
     [[ -z "$ref" ]] && continue
     file=$(echo "$ref" | cut -d: -f1)
-    adr_num=$(echo "$ref" | grep -oP 'ADR-00\K[0-9]' | head -1)
+    adr_num=$(echo "$ref" | sed -nE 's/.*ADR-00([0-9]).*/\1/p' | head -1)
     if [ -n "$adr_num" ]; then
         match_count=$(find ADRs -name "00${adr_num}_*.md" 2>/dev/null | wc -l)
         if [ "$match_count" -eq 0 ]; then
@@ -72,7 +72,7 @@ echo "--- Checking protocol file references ---"
 while IFS= read -r ref; do
     [[ -z "$ref" ]] && continue
     file=$(echo "$ref" | cut -d: -f1)
-    proto=$(echo "$ref" | grep -oP 'contributor_protocols/[a-z_]+\.md' | head -1)
+    proto=$(echo "$ref" | sed -nE 's|.*(contributor_protocols/[a-z_]+\.md).*|\1|p' | head -1)
     if [ -n "$proto" ] && [ ! -f "$proto" ]; then
         echo "  ERROR: $file references $proto but file does not exist"
         errors=$((errors + 1))

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -6,8 +6,8 @@
 | Owner             | Simon Polichinel von der Maase       |
 | Last Updated      | 2026-04-10                           |
 | Total Concerns    | 53                                   |
-| Open Concerns     | 24                                   |
-| Resolved Concerns | 29                                   |
+| Open Concerns     | 21                                   |
+| Resolved Concerns | 32                                   |
 
 ---
 
@@ -162,22 +162,6 @@ All `biopsy_*` methods wrap their body in `try/except Exception` and log on fail
 
 ---
 
-### C-22: `cast(Any, model)` at 7+ call sites bypasses type safety
-
-| Field | Value |
-|-------|-------|
-| ID | C-22 |
-| Tier | 4 |
-| Source | expert-review (2026-04-08) |
-| Trigger | Changing the model's `forward()` return signature |
-| Location | `train_model.py:105,199,242`, `hydranet_inference.py:122,137,147,151,157,225,257` |
-
-The model's return type is untyped; 7+ call sites use `cast(Any, model)(input, h)` to suppress type checking. The actual contract (returns `(out_reg, out_class, h)` tuple) is invisible at every call site. A `Protocol` type would make the interface explicit and catch signature changes statically.
-
-Per Martin (Clean Architecture Ch 11, p.104-108): DIP says "depend on abstractions, not on concretions." Every `cast(Any, model)` call is a concrete dependency on the model's undeclared interface. Martin's coding practice (p.105): "Don't refer to volatile concrete classes." A `Protocol` defining `__call__(x, h) -> (Tensor, Tensor, Tensor)` would invert this dependency, making the contract explicit and verifiable at type-check time.
-
----
-
 ### C-26: VisualDiagnostics plot correctness untested
 
 | Field | Value |
@@ -300,20 +284,6 @@ Per Martin (Clean Architecture Ch 22, p.203-209): "Source code dependencies must
 
 ---
 
-### C-40: `validate_docs.sh` uses GNU-only `grep -oP` (not portable to macOS)
-
-| Field | Value |
-|-------|-------|
-| ID | C-40 |
-| Tier | 4 |
-| Source | pr-review (2026-04-08) |
-| Trigger | macOS contributor running `bash docs/validate_docs.sh` |
-| Location | `docs/validate_docs.sh:60,75` |
-
-Two `grep -oP` calls use Perl-compatible regex (`-P` flag), which requires GNU grep. macOS ships BSD grep, which does not support `-P`. The script will fail with an error on macOS unless the user has GNU grep installed or aliased. Currently low-impact: all known contributors use Linux, the script is a manual governance tool (not CI), and failure is loud and non-destructive. Fix is straightforward: rewrite with `sed -E` or `awk` for POSIX portability. Script was copied verbatim from base_docs template — fix should be upstreamed there as well.
-
----
-
 ### C-41: Falsification test stubs will fail in CI if not excluded
 
 | Field | Value |
@@ -359,20 +329,6 @@ The autoresearch found that Shrinkage loss with `c=1.0` marginally outperforms B
 The alternative is nested structure: `regularizers: { qs99: { weight: 0.01, tau: 0.99 } }`. This is cleaner for extensibility but breaks the flat-key pattern, complicates Pydantic validation, and requires changes to the genome audit.
 
 Current decision: stay flat. Revisit when either (a) total config keys exceed 50, or (b) a feature requires 4+ related keys that create naming collision risk. The migration is mechanical (rename keys, update configs) but touches every model config in views-models.
-
----
-
-### C-50: Derivation asymmetry — DataFrame path skips, Volume path raises
-
-| Field | Value |
-|-------|-------|
-| ID | C-50 |
-| Tier | 3 |
-| Source | repo-assimilation (2026-04-10) |
-| Trigger | When calling `prepare_actuals_df()` on a ground-truth DataFrame that lacks a derivation source column, verify derived classification targets are present in the output |
-| Location | `data_fetcher.py:161-166` (skip), `volume_handler.py:724-730` (raise) |
-
-`DataFetcher.apply_blueprint()` silently skips derivations when the source column is missing from the DataFrame, while `VolumeHandler._execute_derivations()` raises `ValueError` for the same condition. This asymmetry is documented in code comments (cross-ref lines in both files) and tested in `test_derivation_parity.py`. The risk is that `prepare_actuals_df()` — used to manufacture derived signals for evaluation ground truth — may produce a DataFrame lacking binary classification targets (e.g., `by_sb_best`) without error, causing evaluation to compare model output against incomplete ground truth. Currently mitigated by the fact that derivation source columns (regression targets like `lr_sb_best`) are always present in the ground-truth DataFrame; their absence would indicate a deeper data pipeline failure.
 
 ---
 
@@ -658,6 +614,36 @@ See also C-20 (resolved — added the soft warning).
 | ID | C-28 |
 | Resolved | 2026-04-08 |
 | Resolution | Updated test alignment sections in HydranetManager.md, HydraNetConfig.md, and ConfigInitializer.md to reference actual test files (test_config_typed.py, test_config_validation.py, test_manager_memory_hygiene.py, etc.) |
+
+---
+
+### C-22: `cast(Any, model)` at 7+ call sites bypasses type safety — RESOLVED
+
+| Field | Value |
+|-------|-------|
+| ID | C-22 |
+| Resolved | 2026-04-10 |
+| Resolution | Defined `ModelOutput` NamedTuple in `architectures/HydraBNrecurrentUnet_06_LSTM4.py` with `reg`, `cls`, `h_next` fields. `forward()` now returns `ModelOutput(...)`; NamedTuple supports tuple unpacking so legacy `r, c, h = model(x, h)` continues to work. Removed `cast(Any, model)` wrappers in `training_engine.py` and `hydranet_inference.py` — consumers now use named access (`output.reg`, `output.cls`, `output.h_next`) or simple unpacking. Updated 5 test mocks (conftest.py TinyModel, test_temporal_causality_audit, test_inference_logic, test_inference_memory_hygiene, test_cluster_e, test_optimization_gate) to return ModelOutput. The remaining `cast(Any, multitaskloss_instance)` is unrelated to C-22. |
+
+---
+
+### C-40: `validate_docs.sh` uses GNU-only `grep -oP` — RESOLVED
+
+| Field | Value |
+|-------|-------|
+| ID | C-40 |
+| Resolved | 2026-04-10 |
+| Resolution | Replaced both `grep -oP` calls in `docs/validate_docs.sh` with portable `sed -nE` regex extraction. Lines 60 (ADR number extraction) and 75 (protocol path extraction) now work on macOS BSD grep. Script verified — `bash docs/validate_docs.sh` passes cleanly. Should be upstreamed to base_docs template. |
+
+---
+
+### C-50: Derivation asymmetry — DataFrame path skips, Volume path raises — RESOLVED
+
+| Field | Value |
+|-------|-------|
+| ID | C-50 |
+| Resolved | 2026-04-10 |
+| Resolution | Made `DataFetcher.apply_blueprint()` raise `ValueError` (matching `VolumeHandler._execute_derivations()`) when a derivation source column is missing from the DataFrame. Updated cross-reference comments in both files. Updated `test_data_fetcher.py`: removed `test_beige_blueprint_missing_source_skips`, added `test_red_blueprint_missing_source_raises`. The two paths now have symmetric behavior verified by `test_derivation_parity.py` and the new red test. |
 
 ---
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import pytest
 import torch
 import torch.nn as nn
 
+from views_hydranet.architectures.HydraBNrecurrentUnet_06_LSTM4 import ModelOutput
+
 # --- Minimum test count gate ---
 # Catches silent test collection failures (e.g., broken imports from
 # views_pipeline_core) before they erode coverage unnoticed.
@@ -44,7 +46,11 @@ class TinyModel(nn.Module):
 
     def forward(self, x, h):
         combined = torch.cat([x, h], dim=1)
-        return self.reg_head(combined), self.cls_head(combined), self.h_update(combined)
+        return ModelOutput(
+            reg=self.reg_head(combined),
+            cls=self.cls_head(combined),
+            h_next=self.h_update(combined),
+        )
 
     def init_hTtime(self, hidden_channels, H, W):
         return torch.zeros(1, hidden_channels, H, W)

--- a/tests/test_cluster_e.py
+++ b/tests/test_cluster_e.py
@@ -8,6 +8,8 @@ C-48: QS99 tail regularizer (distribution-free pinball)
 
 import torch
 
+from views_hydranet.architectures.HydraBNrecurrentUnet_06_LSTM4 import ModelOutput
+
 
 # ---------------------------------------------------------------------------
 # C-47: ParetoLoss
@@ -278,9 +280,6 @@ def _make_tiny_model():
             self.base = 8
 
         def forward(self, x, h):
-            from views_hydranet.architectures.HydraBNrecurrentUnet_06_LSTM4 import (
-                ModelOutput,
-            )
             out = self.conv(x)
             return ModelOutput(reg=out, cls=out, h_next=h)
 

--- a/tests/test_cluster_e.py
+++ b/tests/test_cluster_e.py
@@ -278,8 +278,11 @@ def _make_tiny_model():
             self.base = 8
 
         def forward(self, x, h):
+            from views_hydranet.architectures.HydraBNrecurrentUnet_06_LSTM4 import (
+                ModelOutput,
+            )
             out = self.conv(x)
-            return out, out, h
+            return ModelOutput(reg=out, cls=out, h_next=h)
 
         def init_hTtime(self, hidden_channels, H, W):
             return torch.zeros(1, hidden_channels, H, W)

--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -142,20 +142,19 @@ class TestBeige:
         result = DataFetcher.standardize_raw_df(df, _base_config())
         assert "extra_col" in result.columns
 
-    def test_beige_blueprint_missing_source_skips(self):
-        """Missing source column -> silent skip."""
-        df = pd.DataFrame({"a": [1, 2]})
-        cfg = _base_config(derivations={
-            "binary": [{"from": "nonexistent", "to": "out", "threshold": 0.5}]
-        })
-        result = DataFetcher.apply_blueprint(df, cfg)
-        assert "out" not in result.columns
-
-
 # ---------------------------------------------------------------------------
 # RED TEAM — failure detection
 # ---------------------------------------------------------------------------
 class TestRed:
+    def test_red_blueprint_missing_source_raises(self):
+        """C-50: Missing source column raises (matches VolumeHandler behavior)."""
+        df = pd.DataFrame({"a": [1, 2]})
+        cfg = _base_config(derivations={
+            "binary": [{"from": "nonexistent", "to": "out", "threshold": 0.5}]
+        })
+        with pytest.raises(ValueError, match="Source column 'nonexistent' not found"):
+            DataFetcher.apply_blueprint(df, cfg)
+
     def test_red_non_multiindex_raises(self):
         """RangeIndex -> ValueError."""
         df = pd.DataFrame({"a": [1, 2]})

--- a/tests/test_inference_logic.py
+++ b/tests/test_inference_logic.py
@@ -2,6 +2,7 @@
 import pytest
 import torch
 
+from views_hydranet.architectures.HydraBNrecurrentUnet_06_LSTM4 import ModelOutput
 from views_hydranet.utils.hydranet_inference import HydraNetInference
 
 
@@ -17,7 +18,7 @@ class MockModel(torch.nn.Module):
         # Dummy predictions
         reg = torch.randn(x.shape[0], 3, x.shape[2], x.shape[3])
         cls = torch.randn(x.shape[0], 3, x.shape[2], x.shape[3])
-        return reg, cls, h_new
+        return ModelOutput(reg=reg, cls=cls, h_next=h_new)
 
 @pytest.fixture
 def inf_setup():

--- a/tests/test_inference_memory_hygiene.py
+++ b/tests/test_inference_memory_hygiene.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import torch
 
+from views_hydranet.architectures.HydraBNrecurrentUnet_06_LSTM4 import ModelOutput
 from views_hydranet.utils.hydranet_inference import HydraNetInference
 from views_hydranet.utils.volume_handler import VolumeHandler
 
@@ -96,7 +97,7 @@ class _MinimalModel(torch.nn.Module):
         B, _, H, W = x.shape
         reg = torch.zeros(B, 3, H, W)
         cls = torch.zeros(B, 3, H, W)
-        return reg, cls, h
+        return ModelOutput(reg=reg, cls=cls, h_next=h)
 
 
 def _make_mock_inference(config=None) -> HydraNetInference:

--- a/tests/test_optimization_gate.py
+++ b/tests/test_optimization_gate.py
@@ -67,8 +67,11 @@ class TestOptimizationGate:
                 "expected 2 (features 'f1' and 'by_f1'). "
                 "Identity column 't' must be stripped before the model sees the tensor."
             )
+            from views_hydranet.architectures.HydraBNrecurrentUnet_06_LSTM4 import (
+                ModelOutput,
+            )
             pred = torch.ones((1, 1, 1, 1), requires_grad=True)
-            return pred, pred, h
+            return ModelOutput(reg=pred, cls=pred, h_next=h)
 
         model.forward = mock_forward
 

--- a/tests/test_optimization_gate.py
+++ b/tests/test_optimization_gate.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import torch
 
+from views_hydranet.architectures.HydraBNrecurrentUnet_06_LSTM4 import ModelOutput
 from views_hydranet.train.train_model import training_loop
 from views_hydranet.utils.volume_handler import VolumeHandler
 
@@ -66,9 +67,6 @@ class TestOptimizationGate:
                 f"mock_forward received t0 with {t0.shape[1]} channels; "
                 "expected 2 (features 'f1' and 'by_f1'). "
                 "Identity column 't' must be stripped before the model sees the tensor."
-            )
-            from views_hydranet.architectures.HydraBNrecurrentUnet_06_LSTM4 import (
-                ModelOutput,
             )
             pred = torch.ones((1, 1, 1, 1), requires_grad=True)
             return ModelOutput(reg=pred, cls=pred, h_next=h)

--- a/tests/test_temporal_causality_audit.py
+++ b/tests/test_temporal_causality_audit.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import torch
 
+from views_hydranet.architectures.HydraBNrecurrentUnet_06_LSTM4 import ModelOutput
 from views_hydranet.utils.hydranet_inference import HydraNetInference
 
 
@@ -21,7 +22,7 @@ class CausalMockModel(torch.nn.Module):
         t1_pred = x + 0.1
         t1_cls = torch.zeros_like(t1_pred)
         h_new = h + 0.01
-        return t1_pred, t1_cls, h_new
+        return ModelOutput(reg=t1_pred, cls=t1_cls, h_next=h_new)
 
 @pytest.fixture
 def causal_setup():

--- a/views_hydranet/architectures/HydraBNrecurrentUnet_06_LSTM4.py
+++ b/views_hydranet/architectures/HydraBNrecurrentUnet_06_LSTM4.py
@@ -1,6 +1,22 @@
+from typing import NamedTuple
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+
+class ModelOutput(NamedTuple):
+    """
+    Typed return value for HydraBNUNet06_LSTM4.forward().
+
+    Replaces the implicit (out_reg, out_class, h) tuple with named fields,
+    eliminating cast(Any, model) at consumer sites (C-22). NamedTuple supports
+    tuple unpacking, so legacy `r, c, h = model(x, h)` continues to work.
+    """
+
+    reg: torch.Tensor       # [B, n_reg, H, W] regression head outputs
+    cls: torch.Tensor       # [B, n_cls, H, W] classification head logits
+    h_next: torch.Tensor    # [B, total_hidden_channels, H, W] LSTM hidden state
 
 
 # give everything better names at some point
@@ -343,9 +359,8 @@ class HydraBNUNet06_LSTM4(nn.Module):
             h (torch.Tensor): Combined hidden state [batch, total_hidden_channels, H, W].
 
         Returns:
-            out_reg (torch.Tensor): Concatenated regression heads [batch, 3, H, W].
-            out_class (torch.Tensor): Concatenated classification heads [batch, 3, H, W].
-            h_next (torch.Tensor): Updated hidden state [batch, total_hidden_channels, H, W].
+            ModelOutput: NamedTuple with `reg`, `cls`, `h_next` fields. Supports
+                tuple unpacking for backward compatibility.
         """
 
         # Splitting hidden state into 4 short-term and 4 long-term memory tensors.
@@ -499,7 +514,7 @@ class HydraBNUNet06_LSTM4(nn.Module):
         out_reg = torch.concat([out_reg1, out_reg2, out_reg3], dim=1)
         out_class = torch.concat([out_class1, out_class2, out_class3], dim=1)
 
-        return out_reg, out_class, h
+        return ModelOutput(reg=out_reg, cls=out_class, h_next=h)
 
     def init_hTtime(self, hidden_channels, H, W):
         """

--- a/views_hydranet/train/training_engine.py
+++ b/views_hydranet/train/training_engine.py
@@ -149,7 +149,8 @@ def _process_sequence(
 
         # Forward pass: Feed ONLY the input features (Zero Magic)
         t0_input = t0[:, idx.feat, :, :]
-        t1_pred, t1_pred_class, h = cast(Any, model)(t0_input, h)
+        output = model(t0_input, h)
+        t1_pred, t1_pred_class, h = output.reg, output.cls, output.h_next
 
         # --- FORENSIC RECORDING (ADR 001 Custodian) ---
         if forensics:
@@ -301,11 +302,9 @@ def train(
     )
 
     # 4. Initialize hidden state
-    h = (
-        cast(Any, model)
-        .init_hTtime(hidden_channels=model.base, H=window_H, W=window_W)
-        .to(device)
-    )
+    h = model.init_hTtime(
+        hidden_channels=model.base, H=window_H, W=window_W
+    ).to(device)
 
     # 5. STAGE 5 DIAGNOSTIC
     acc_y_reg: list[np.ndarray] = []
@@ -341,17 +340,18 @@ def train(
 
         # Re-run the midpoint steps in eval mode for diagnostic capture only
         model.eval()
-        h_diag = (
-            cast(Any, model)
-            .init_hTtime(hidden_channels=model.base, H=window_H, W=window_W)
-            .to(device)
-        )
+        h_diag = model.init_hTtime(
+            hidden_channels=model.base, H=window_H, W=window_W
+        ).to(device)
         with torch.no_grad():
             for i in range(seq_len - 1):
                 t0 = train_tensor[:, i, :, :, :]
                 t1 = train_tensor[:, i + 1, :, :, :]
                 t0_input = t0[:, idx.feat, :, :]
-                t1_pred, t1_pred_class, h_diag = cast(Any, model)(t0_input, h_diag)
+                output_diag = model(t0_input, h_diag)
+                t1_pred = output_diag.reg
+                t1_pred_class = output_diag.cls
+                h_diag = output_diag.h_next
 
                 if biopsy_start <= i < biopsy_end:
                     y_reg = t1[:, idx.reg, :, :]

--- a/views_hydranet/train/training_engine.py
+++ b/views_hydranet/train/training_engine.py
@@ -349,9 +349,9 @@ def train(
                 t1 = train_tensor[:, i + 1, :, :, :]
                 t0_input = t0[:, idx.feat, :, :]
                 output_diag = model(t0_input, h_diag)
-                t1_pred = output_diag.reg
-                t1_pred_class = output_diag.cls
-                h_diag = output_diag.h_next
+                t1_pred, t1_pred_class, h_diag = (
+                    output_diag.reg, output_diag.cls, output_diag.h_next
+                )
 
                 if biopsy_start <= i < biopsy_end:
                     y_reg = t1[:, idx.reg, :, :]

--- a/views_hydranet/utils/data_fetcher.py
+++ b/views_hydranet/utils/data_fetcher.py
@@ -133,8 +133,7 @@ class DataFetcher:
         return DataFetcher.apply_blueprint(df_out, config)
 
     # Cross-ref: VolumeHandler._execute_derivations() (volume_handler.py)
-    # This path SKIPS if source missing; volume path RAISES.
-    # See tests/test_derivation_parity.py for parity guard.
+    # Both paths RAISE if source is missing — see tests/test_derivation_parity.py.
     @staticmethod
     def apply_blueprint(df: pd.DataFrame, config: Dict[str, Any]) -> pd.DataFrame:
         """
@@ -159,12 +158,12 @@ class DataFetcher:
                     raise KeyError(err_msg)
 
                 if src_name not in df_out.columns:
-                    # If the source is missing, we can't derive.
-                    logger.debug(
-                        f"DataFetcher Blueprint: Source '{src_name}' missing. "
-                        "Skipping derivation."
+                    err_msg = (
+                        f"DataFetcher Blueprint Error: Source column '{src_name}' "
+                        f"not found in DataFrame. Available columns: {list(df_out.columns)}"
                     )
-                    continue
+                    logger.error(err_msg)
+                    raise ValueError(err_msg)
 
                 if op == "binary":
                     if "threshold" not in instr:

--- a/views_hydranet/utils/data_fetcher.py
+++ b/views_hydranet/utils/data_fetcher.py
@@ -158,9 +158,12 @@ class DataFetcher:
                     raise KeyError(err_msg)
 
                 if src_name not in df_out.columns:
+                    cols = list(df_out.columns)
+                    cols_preview = cols[:10] if len(cols) > 10 else cols
+                    suffix = f" (+{len(cols) - 10} more)" if len(cols) > 10 else ""
                     err_msg = (
                         f"DataFetcher Blueprint Error: Source column '{src_name}' "
-                        f"not found in DataFrame. Available columns: {list(df_out.columns)}"
+                        f"not found in DataFrame. Available: {cols_preview}{suffix}"
                     )
                     logger.error(err_msg)
                     raise ValueError(err_msg)

--- a/views_hydranet/utils/hydranet_inference.py
+++ b/views_hydranet/utils/hydranet_inference.py
@@ -1,6 +1,6 @@
 import gc
 import logging
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, cast
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -222,7 +222,7 @@ class HydraNetInference:
 
         # Initialize hidden state
         h_tt = (
-            cast(Any, self.model).init_hTtime(hidden_channels=self.model.base, H=H, W=W)
+            self.model.init_hTtime(hidden_channels=self.model.base, H=H, W=W)
             .float()
             .to(self.device)
         )
@@ -249,12 +249,13 @@ class HydraNetInference:
             if t < origin:
                 # 1. HISTORY DIGESTION: Update hidden state only
                 t0_input = full_tensor[:, t, feat_indices, :, :]
-                _, _, h_tt = cast(Any, self.model)(t0_input, h_tt)
+                h_tt = self.model(t0_input, h_tt).h_next
 
             elif t == origin:
                 # 2. SEED STEP: Month Origin -> Month Origin + 1 (Step 1)
                 t0_input = full_tensor[:, t, feat_indices, :, :]
-                t1_pred, t1_pred_class, h_tt = cast(Any, self.model)(t0_input, h_tt)
+                output = self.model(t0_input, h_tt)
+                t1_pred, t1_pred_class, h_tt = output.reg, output.cls, output.h_next
                 t1_pred_class = torch.sigmoid(t1_pred_class)
 
                 acc_magnitudes.append(t1_pred)

--- a/views_hydranet/utils/volume_handler.py
+++ b/views_hydranet/utils/volume_handler.py
@@ -696,8 +696,7 @@ class VolumeHandler:
         return self._metadata.spatial_offset
 
     # Cross-ref: DataFetcher.apply_blueprint() (data_fetcher.py)
-    # This path RAISES if source missing; DataFrame path SKIPS.
-    # See tests/test_derivation_parity.py for parity guard.
+    # Both paths RAISE if source is missing — see tests/test_derivation_parity.py.
     def _execute_derivations(self, derivations_config: Dict[str, List[Dict[str, Any]]]) -> None:
         """
         Executes additive feature engineering instructions (ADR 046).


### PR DESCRIPTION
## Summary

Three-item sprint from review-rr prioritize:

- **C-50 (Tier 3) RESOLVED:** \`DataFetcher.apply_blueprint()\` now raises \`ValueError\` when a derivation source column is missing — matches \`VolumeHandler._execute_derivations()\` behavior. Eliminates the asymmetry that could allow silent ground-truth incompleteness.
- **C-22 (Tier 4, strategic) RESOLVED:** Defined \`ModelOutput\` NamedTuple in \`HydraBNUNet06_LSTM4\`. \`forward()\` returns it; tuple unpacking still works. Removed all \`cast(Any, model)\` wrappers in training and inference code. Unblocks the weight head research avenue cleanly.
- **C-40 (Tier 4) RESOLVED:** Replaced \`grep -oP\` with \`sed -nE\` in \`docs/validate_docs.sh\` (2 locations). Now portable to macOS BSD grep.

## Test plan

- [x] All 6 mock models updated to return \`ModelOutput\`: conftest.py, test_temporal_causality_audit, test_inference_logic, test_inference_memory_hygiene, test_cluster_e, test_optimization_gate
- [x] \`bash docs/validate_docs.sh\` passes (verifies the sed replacement)
- [x] Full suite: 412 passed, 2 failed (1 intentional RED C-33 + 1 pre-existing data_fetcher mock)
- [x] \`ruff check .\` clean
- [x] Register header verified: 53 total, 21 open, 32 resolved

## Strategic value

C-22's resolution introduces \`ModelOutput\` — the prerequisite for the weight head research avenue. Adding the weight head is now a single-line change to the NamedTuple (\`weights: Tensor | None = None\`) with no consumer breakage required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)