### PR TITLE
fix: relax anchor alignment for sparse grid regions

### DIFF
--- a/docs/CICs/DataSniffer.md
+++ b/docs/CICs/DataSniffer.md
@@ -52,7 +52,7 @@ The `DataSniffer` is the **Sentinel** of the HydraNet pipeline. Its primary purp
 
 - **Uniqueness Violation:** Fails if duplicate Time/ID pairs are detected (prevents rasterization bugs).
 - **Discontinuity:** Fails loud if a forecast start month does not immediately follow the history end month.
-- **Anchor Violation:** Raises a critical error if geographic offsets (`row_offset`, `col_offset`) drift between data partitions.
+- **Anchor Violation:** Raises a critical error if data coordinates fall below the configured offsets (`row_offset`, `col_offset`), or if offsets drift between data partitions. When data starts above the offset (sparse regions), logs a warning but does not raise.
 - **Non-Finite Identities:** Fails if mandatory identity columns (`month_id`, `row`, `col`) contain `NaN` or `Inf`.
 
 ---

--- a/tests/test_datasniffer_offset_drift.py
+++ b/tests/test_datasniffer_offset_drift.py
@@ -13,6 +13,8 @@ config was later changed (or vice versa), spatial scrambling occurs
 silently. This file closes that blind spot.
 """
 
+import logging
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -209,28 +211,21 @@ def test_sniffer_ingestion_rejects_anchor_below_offset():
         sniffer.sniff_ingestion(df)
 
 
-def test_sniffer_ingestion_rejects_anchor_above_offset():
+def test_sniffer_ingestion_warns_anchor_above_offset(caplog):
     """
-    RED GATE: sniff_ingestion() must raise when df['row'].min() > config['row_offset'].
+    BEIGE GATE: sniff_ingestion() must NOT raise when df['row'].min() > config['row_offset'].
 
-    Failure mode: data starts AFTER the configured anchor — the most dangerous
-    silent case. r_idx.min() = 3 means rows 0-2 of the volume are silent zeros.
-    VolumeHandler does NOT raise (no negative indices, no out-of-bounds).
-    Only this check can catch it.
-
-    Example: config says row_offset=87 but the data provider has silently trimmed
-    the first 3 rows of the Africa grid, starting at row 90 instead. The model
-    trains on a spatially-shifted grid and no error is ever raised.
-
-    Taxonomy (ADR 005): RED — the most dangerous silent failure mode.
+    Sparse regions (e.g. land cells in a 360×720 global grid) legitimately start
+    above the configured offset. Leading zero rows/cols in the volume are expected.
+    The sniffer logs a warning but does not halt the pipeline.
     """
-    # Data starts at row 90, but config says grid starts at row 87.
-    # Rows 87, 88, 89 of the volume are silently zero. No VolumeHandler guard fires.
     sniffer = DataSniffer(INGEST_CFG)
     df = _make_ingest_df(row_min=90, col_min=310)
 
-    with pytest.raises(ValueError, match=r"[Aa]nchor|[Oo]ffset|[Aa]lign"):
+    with caplog.at_level(logging.WARNING):
         sniffer.sniff_ingestion(df)
+
+    assert any("sparse regions" in msg for msg in caplog.messages)
 
 
 def test_sniffer_ingestion_accepts_correct_anchor():

--- a/views_hydranet/utils/data_sniffer.py
+++ b/views_hydranet/utils/data_sniffer.py
@@ -187,21 +187,19 @@ class DataSniffer:
 
     def _check_anchor_alignment(self, df: pd.DataFrame) -> None:
         """
-        Verifies that df['row'].min() == config['row_offset'] and
-        df['col'].min() == config['col_offset'].
+        Verifies that df['row'].min() >= config['row_offset'] and
+        df['col'].min() >= config['col_offset'].
 
-        Two distinct silent failure modes are caught here:
+        Catches one critical silent failure mode:
 
-        1. df.min < offset (e.g. data at row 80 when offset=87):
-           r_idx = 80 - 87 = -7 → negative numpy fancy index → spatial wrap.
-           VolumeHandler's guard will catch this, but only AFTER the volume
-           starts building. This check fires before the volume exists.
+        df.min < offset (e.g. data at row 80 when offset=87):
+          r_idx = 80 - 87 = -7 → negative numpy fancy index → spatial wrap.
+          VolumeHandler's guard will catch this, but only AFTER the volume
+          starts building. This check fires before the volume exists.
 
-        2. df.min > offset (e.g. data starts at row 90 when offset=87):
-           r_idx.min() = 3 → rows 0-2 of the volume are silently zero.
-           VolumeHandler does NOT raise for this case. This is the ONLY gate
-           that catches it. The model trains on a spatially-shifted grid with
-           no error ever surfacing.
+        When df.min > offset (e.g. region=land in a 360×720 volume), the
+        leading rows/cols of the volume are zero. This is expected for sparse
+        regions and is logged as a warning rather than raising.
 
         The check is skipped if row_offset/col_offset are absent from config
         (backwards-compatible with callers that do not set explicit offsets).
@@ -216,33 +214,41 @@ class DataSniffer:
         actual_r_min = df[y_col].min()
         actual_c_min = df[x_col].min()
 
-        if actual_r_min != cfg_r_off:
+        if actual_r_min < cfg_r_off:
             err_msg = (
                 "[CRITICAL DATA ERROR] DataSniffer: Geographic Anchor Alignment Failure!\n"
                 f"Config declares row_offset={cfg_r_off}, but "
                 f"df['{y_col}'].min() = {actual_r_min}.\n"
-                f"Expected: df['{y_col}'].min() == row_offset ({cfg_r_off}).\n"
-                "If actual < offset: negative r_idx → spatial wrap (VolumeHandler will raise).\n"
-                f"If actual > offset: rows 0..{actual_r_min - cfg_r_off - 1} of the volume "
-                "are silently zero — spatial shift with NO downstream error. "
+                f"Data below offset → negative r_idx → spatial wrap. "
                 "Correct either the config row_offset or the data source."
             )
             logger.error(err_msg)
             raise ValueError(err_msg)
 
-        if actual_c_min != cfg_c_off:
+        if actual_r_min > cfg_r_off:
+            logger.info(
+                "Anchor: df['%s'].min()=%d > row_offset=%d — "
+                "rows 0..%d of the volume will be zero (expected for sparse regions).",
+                y_col, actual_r_min, cfg_r_off, int(actual_r_min - cfg_r_off - 1),
+            )
+
+        if actual_c_min < cfg_c_off:
             err_msg = (
                 "[CRITICAL DATA ERROR] DataSniffer: Geographic Anchor Alignment Failure!\n"
                 f"Config declares col_offset={cfg_c_off}, but "
                 f"df['{x_col}'].min() = {actual_c_min}.\n"
-                f"Expected: df['{x_col}'].min() == col_offset ({cfg_c_off}).\n"
-                "If actual < offset: negative c_idx → spatial wrap (VolumeHandler will raise).\n"
-                f"If actual > offset: cols 0..{actual_c_min - cfg_c_off - 1} of the volume "
-                "are silently zero — spatial shift with NO downstream error. "
+                f"Data below offset → negative c_idx → spatial wrap. "
                 "Correct either the config col_offset or the data source."
             )
             logger.error(err_msg)
             raise ValueError(err_msg)
+
+        if actual_c_min > cfg_c_off:
+            logger.info(
+                "Anchor: df['%s'].min()=%d > col_offset=%d — "
+                "cols 0..%d of the volume will be zero (expected for sparse regions).",
+                x_col, actual_c_min, cfg_c_off, int(actual_c_min - cfg_c_off - 1),
+            )
 
     def _check_spatial_bounds(self, df: pd.DataFrame, y_col: str, x_col: str) -> None:
         """Verifies that the span of indices fits within the configured volume resolution."""

--- a/views_hydranet/utils/data_sniffer.py
+++ b/views_hydranet/utils/data_sniffer.py
@@ -226,7 +226,7 @@ class DataSniffer:
             raise ValueError(err_msg)
 
         if actual_r_min > cfg_r_off:
-            logger.info(
+            logger.warning(
                 "Anchor: df['%s'].min()=%d > row_offset=%d — "
                 "rows 0..%d of the volume will be zero (expected for sparse regions).",
                 y_col, actual_r_min, cfg_r_off, int(actual_r_min - cfg_r_off - 1),
@@ -244,7 +244,7 @@ class DataSniffer:
             raise ValueError(err_msg)
 
         if actual_c_min > cfg_c_off:
-            logger.info(
+            logger.warning(
                 "Anchor: df['%s'].min()=%d > col_offset=%d — "
                 "cols 0..%d of the volume will be zero (expected for sparse regions).",
                 x_col, actual_c_min, cfg_c_off, int(actual_c_min - cfg_c_off - 1),


### PR DESCRIPTION
## Summary

- DataSniffer's `_check_anchor_alignment()` now only raises when `df['row'].min() < row_offset` (negative indices → spatial wrap)
- When `df['row'].min() > row_offset` (sparse region like `land` in a 360×720 volume), logs an info message instead of raising — zero-filled leading rows are expected

## Context

When using `region=land` with a full 360×720 grid volume, the first ~68 rows are ocean (no data). The strict equality check (`min == offset`) rejected this as a "geographic anchor alignment failure", but the zero-filled rows are correct behavior for sparse regions.

The dangerous case (`min < offset` → negative array indices → spatial wrap) is still caught and raises.

Companion PR in views-models corrects heavy_freighter's offset from 0 → 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)