### PR TITLE
fix: strict conditional parameter validation for loss functions

### DIFF
--- a/docs/CICs/HydraNetConfig.md
+++ b/docs/CICs/HydraNetConfig.md
@@ -23,7 +23,7 @@ The `HydraNetConfig` is the **Schema** of the HydraNet pipeline. Its primary pur
 
 ## 3. Responsibilities and Guarantees
 
-- **Field Validation:** Guarantees that all 54 fields are type-checked and constraint-validated (e.g., `dropout_rate` in [0.0, 1.0], `input_channels >= 1`).
+- **Field Validation:** Guarantees that all 63 fields are type-checked and constraint-validated (e.g., `dropout_rate` in [0.0, 1.0], `input_channels >= 1`).
 - **Checksum Laws (ADR-009):** Guarantees `input_channels == len(features)` and `time_steps == len(steps)`.
 - **Feature Lifecycle Law (ADR-046):** Guarantees that all required columns (features + targets) are accounted for in `transformations` or `derivations`.
 - **Typo Correction:** Handles the legacy `evalution_mode` typo via a `model_validator(mode="before")` shim.

--- a/docs/CICs/HydraNetConfig.md
+++ b/docs/CICs/HydraNetConfig.md
@@ -28,6 +28,7 @@ The `HydraNetConfig` is the **Schema** of the HydraNet pipeline. Its primary pur
 - **Feature Lifecycle Law (ADR-046):** Guarantees that all required columns (features + targets) are accounted for in `transformations` or `derivations`.
 - **Typo Correction:** Handles the legacy `evalution_mode` typo via a `model_validator(mode="before")` shim.
 - **Enum Validation:** Validates `run_type`, `evaluation_mode`, and `aggregate_method` against strict allowlists, with alias support for `aggregate_method` (e.g., `"mean"` → `"arithmetic_mean"`).
+- **Conditional Parameter Validation:** Guarantees that strategy-specific parameters are explicitly provided for the active choice in `sampling_strategy`, `loss_reg`, and `loss_class`. No silent defaults — missing parameters raise immediately.
 - **Dict Compatibility Layer:** Provides `__getitem__`, `__contains__`, `get()`, and `keys()` for gradual migration from `config["key"]` access patterns.
 
 ---
@@ -54,6 +55,8 @@ The `HydraNetConfig` is the **Schema** of the HydraNet pipeline. Its primary pur
 - **Invalid Evaluation Mode:** Raises `ValueError` with valid options listed — no silent typo correction for `evaluation_mode` (only the legacy `evalution_mode` key name is corrected).
 - **Invalid Loss Function (Regression):** Raises `ValueError` when `loss_reg` is not in `LOSS_REG_REGISTRY`, listing valid options.
 - **Invalid Loss Function (Classification):** Raises `ValueError` when `loss_class` is not in `LOSS_CLASS_REGISTRY`, listing valid options.
+- **Missing Loss Reg Parameter:** Raises `ValueError` when the active regression loss's required parameter is not provided (e.g., `shrinkage` requires `loss_reg_a` and `loss_reg_c`, `basu_dpd` requires `loss_reg_alpha` and `loss_reg_sigma`).
+- **Missing Loss Class Parameter:** Raises `ValueError` when the active classification loss's required parameter is not provided (e.g., `focal` requires `loss_class_alpha` and `loss_class_gamma`).
 - **Invalid Aggregate Method:** Raises `ValueError` when `aggregate_method` is not in `[arithmetic_mean, geometric_mean, median]`.
 - **Degenerate Slope Ratio:** Raises `ValueError` when `slope_ratio <= 0.0` (causes division-by-zero in curriculum).
 - **Degenerate Roof Ratio:** Raises `ValueError` when `roof_ratio <= 0.0` (eliminates curriculum variation).

--- a/tests/test_basu_loss.py
+++ b/tests/test_basu_loss.py
@@ -189,6 +189,7 @@ def test_basu_loss_registered_in_choose_loss():
     config = {
         "loss_reg": "basu_dpd",
         "loss_reg_alpha": 0.5,
+        "loss_reg_sigma": 1.0,
         "loss_class": "bce",
         "regression_targets": ["lr_sb_best"],
         "classification_targets": [],

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -229,3 +229,15 @@ class TestRed:
         cfg = _make_config(valid_config_dict, loss_reg="basu_dpd", loss_reg_alpha=0.5)
         with pytest.raises(ValidationError, match="loss_reg_sigma"):
             HydraNetConfig(**cfg)
+
+    def test_red_missing_lognormal_param_raises(self, valid_config_dict):
+        """lognormal_nll without loss_reg_sigma → ValidationError."""
+        cfg = _make_config(valid_config_dict, loss_reg="lognormal_nll")
+        with pytest.raises(ValidationError, match="loss_reg_sigma"):
+            HydraNetConfig(**cfg)
+
+    def test_red_missing_pareto_param_raises(self, valid_config_dict):
+        """pareto without loss_reg_pareto_alpha → ValidationError."""
+        cfg = _make_config(valid_config_dict, loss_reg="pareto")
+        with pytest.raises(ValidationError, match="loss_reg_pareto_alpha"):
+            HydraNetConfig(**cfg)

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -43,6 +43,22 @@ class TestGreen:
         config = HydraNetConfig(**cfg)
         assert config.evaluation_mode == "point"
 
+    def test_green_mse_needs_no_loss_params(self, valid_config_dict):
+        """mse/bce require no loss-specific params — absence is fine."""
+        cfg = dict(valid_config_dict)
+        for key in [
+            "loss_reg_a",
+            "loss_reg_c",
+            "loss_reg_alpha",
+            "loss_reg_sigma",
+            "loss_reg_pareto_alpha",
+            "loss_class_gamma",
+            "loss_class_alpha",
+        ]:
+            cfg.pop(key, None)
+        config = HydraNetConfig(**cfg)
+        assert config.loss_reg == "mse"
+
     @pytest.mark.parametrize(
         "alias,expected",
         [("mean", "arithmetic_mean"), ("max_aposteriori", "median"), ("median", "median")],
@@ -191,3 +207,25 @@ class TestRed:
         assert "sampling_strategy" in error_text
         assert "evaluation_mode" in error_text
         assert "loss_reg" in error_text
+
+    def test_red_missing_loss_reg_param_raises(self, valid_config_dict):
+        """shrinkage without loss_reg_a/loss_reg_c → ValidationError naming the param."""
+        cfg = _make_config(valid_config_dict, loss_reg="shrinkage")
+        del cfg["loss_reg_a"]
+        del cfg["loss_reg_c"]
+        with pytest.raises(ValidationError, match="loss_reg_a"):
+            HydraNetConfig(**cfg)
+
+    def test_red_missing_loss_class_param_raises(self, valid_config_dict):
+        """focal without loss_class_gamma/loss_class_alpha → ValidationError naming the param."""
+        cfg = _make_config(valid_config_dict, loss_class="focal")
+        del cfg["loss_class_gamma"]
+        del cfg["loss_class_alpha"]
+        with pytest.raises(ValidationError, match="loss_class_"):
+            HydraNetConfig(**cfg)
+
+    def test_red_loss_reg_shared_param_raises(self, valid_config_dict):
+        """basu_dpd with loss_reg_alpha but missing loss_reg_sigma → ValidationError."""
+        cfg = _make_config(valid_config_dict, loss_reg="basu_dpd", loss_reg_alpha=0.5)
+        with pytest.raises(ValidationError, match="loss_reg_sigma"):
+            HydraNetConfig(**cfg)

--- a/tests/test_falsification_loss_param_validation.py
+++ b/tests/test_falsification_loss_param_validation.py
@@ -1,0 +1,20 @@
+"""
+Falsification stubs for PR #34 (strict conditional parameter validation).
+
+F5: CIC §3 field count drift — claims 54 fields, actual is 63.
+"""
+
+from views_hydranet.utils.config_initializer import HydraNetConfig
+
+
+class TestF5_CICFieldCountDrift:
+    """CIC §3 claims 'all 54 fields are type-checked'. Actual count is 63."""
+
+    def test_cic_field_count_matches_actual(self):
+        """CIC §3 field count must match actual model_fields count."""
+        CIC_CLAIMED_COUNT = 63  # from docs/CICs/HydraNetConfig.md §3
+        actual = len(HydraNetConfig.model_fields)
+        assert actual == CIC_CLAIMED_COUNT, (
+            f"CIC §3 claims {CIC_CLAIMED_COUNT} fields but HydraNetConfig has {actual}. "
+            f"Update CIC §3 field count after adding/removing fields."
+        )

--- a/tests/test_falsification_loss_param_validation.py
+++ b/tests/test_falsification_loss_param_validation.py
@@ -1,14 +1,14 @@
 """
 Falsification stubs for PR #34 (strict conditional parameter validation).
 
-F5: CIC §3 field count drift — claims 54 fields, actual is 63.
+F5: CIC §3 field count drift — guard against future miscounts.
 """
 
 from views_hydranet.utils.config_initializer import HydraNetConfig
 
 
 class TestF5_CICFieldCountDrift:
-    """CIC §3 claims 'all 54 fields are type-checked'. Actual count is 63."""
+    """CIC §3 field count must stay in sync with actual model_fields."""
 
     def test_cic_field_count_matches_actual(self):
         """CIC §3 field count must match actual model_fields count."""

--- a/views_hydranet/utils/config_initializer.py
+++ b/views_hydranet/utils/config_initializer.py
@@ -80,17 +80,17 @@ class HydraNetConfig(BaseModel):
     loss_reg: str = Field(...)
     loss_class: str = Field(...)
     # ShrinkageLoss params (loss_reg='shrinkage')
-    loss_reg_a: float = Field(default=10.0)
-    loss_reg_c: float = Field(default=0.2)
+    loss_reg_a: float | None = Field(default=None)
+    loss_reg_c: float | None = Field(default=None)
     # BasuDPDLoss params (loss_reg='basu_dpd')
-    loss_reg_alpha: float = Field(default=0.5)
+    loss_reg_alpha: float | None = Field(default=None)
     # Shared: BasuDPDLoss sigma / LogNormalFixedSigmaLoss sigma
-    loss_reg_sigma: float = Field(default=1.0)
+    loss_reg_sigma: float | None = Field(default=None)
     # ParetoLoss params (loss_reg='pareto')
-    loss_reg_pareto_alpha: float = Field(default=1.0)
+    loss_reg_pareto_alpha: float | None = Field(default=None)
     # FocalLoss params (loss_class='focal')
-    loss_class_gamma: float = Field(default=1.5)
-    loss_class_alpha: float = Field(default=0.75)
+    loss_class_gamma: float | None = Field(default=None)
+    loss_class_alpha: float | None = Field(default=None)
     # Classification head bias initialization (C-44)
     onset_bias_init: float | None = Field(default=None)
     # Hurdle masking (C-45): None = disabled, 0.0 = standard hurdle (y > 0)
@@ -412,6 +412,40 @@ class HydraNetConfig(BaseModel):
             if getattr(self, param) is None:
                 err_msg = (
                     f"sampling_strategy='{self.sampling_strategy}' requires '{param}' "
+                    f"but it was not provided. Add '{param}' to your config."
+                )
+                logger.error(err_msg)
+                raise ValueError(err_msg)
+        return self
+
+    @model_validator(mode="after")
+    def validate_loss_reg_params(self) -> "HydraNetConfig":
+        from views_hydranet.utils.utils import LOSS_REG_REGISTRY
+
+        entry = LOSS_REG_REGISTRY.get(self.loss_reg)
+        if entry is None:
+            return self
+        for param in entry["params"]:
+            if getattr(self, param) is None:
+                err_msg = (
+                    f"loss_reg='{self.loss_reg}' requires '{param}' "
+                    f"but it was not provided. Add '{param}' to your config."
+                )
+                logger.error(err_msg)
+                raise ValueError(err_msg)
+        return self
+
+    @model_validator(mode="after")
+    def validate_loss_class_params(self) -> "HydraNetConfig":
+        from views_hydranet.utils.utils import LOSS_CLASS_REGISTRY
+
+        entry = LOSS_CLASS_REGISTRY.get(self.loss_class)
+        if entry is None:
+            return self
+        for param in entry["params"]:
+            if getattr(self, param) is None:
+                err_msg = (
+                    f"loss_class='{self.loss_class}' requires '{param}' "
                     f"but it was not provided. Add '{param}' to your config."
                 )
                 logger.error(err_msg)

--- a/views_hydranet/utils/utils.py
+++ b/views_hydranet/utils/utils.py
@@ -58,22 +58,22 @@ LOSS_REG_REGISTRY: Dict[str, Any] = {
         "cls": BasuDPDLoss,
         "params": ["loss_reg_alpha", "loss_reg_sigma"],
         "factory": lambda config, device: BasuDPDLoss(
-            alpha=config.get("loss_reg_alpha", 0.5),
-            sigma=config.get("loss_reg_sigma", 1.0),
+            alpha=config["loss_reg_alpha"],
+            sigma=config["loss_reg_sigma"],
         ).to(device),
     },
     "lognormal_nll": {
         "cls": LogNormalFixedSigmaLoss,
         "params": ["loss_reg_sigma"],
         "factory": lambda config, device: LogNormalFixedSigmaLoss(
-            sigma=config.get("loss_reg_sigma", 0.9),
+            sigma=config["loss_reg_sigma"],
         ).to(device),
     },
     "pareto": {
         "cls": ParetoLoss,
         "params": ["loss_reg_pareto_alpha"],
         "factory": lambda config, device: ParetoLoss(
-            alpha=config.get("loss_reg_pareto_alpha", 1.0),
+            alpha=config["loss_reg_pareto_alpha"],
         ).to(device),
     },
 }


### PR DESCRIPTION
## Summary
- Loss function params (`loss_reg_a`, `loss_reg_c`, `loss_reg_alpha`, `loss_reg_sigma`, `loss_reg_pareto_alpha`, `loss_class_gamma`, `loss_class_alpha`) changed from hardcoded defaults to `None` with strict validation — same pattern as sampling strategies (ADR-049)
- Two new `model_validator`s (`validate_loss_reg_params`, `validate_loss_class_params`) raise immediately if the active loss's required params are missing
- Factory lambdas in `utils.py` made consistent: `config.get(key, default)` → `config[key]` (validator guarantees non-None)
- CIC §3 and §6 updated to document the new conditional parameter validation guarantees

## Test plan
- [x] 4 new tests in `test_config_validation.py` (3 red, 1 green)
- [x] `test_basu_loss.py` config dict updated with explicit `loss_reg_sigma`
- [x] Full suite: 542 passed, 7 skipped
- [x] `ruff check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)