### PR TITLE
feat: Tobit censored-normal likelihood loss (#36)

### DIFF
--- a/docs/ADRs/proposed/054_tobit_censored_regression_loss.md
+++ b/docs/ADRs/proposed/054_tobit_censored_regression_loss.md
@@ -80,14 +80,14 @@
   - `output.reg >= 0` always (enforced by `test_reg_latent_is_pre_relu`)
   - Gradient flows to ALL cells including y=0 (enforced by `test_gradient_flows_to_all_cells`)
 
-- **Tests:** 27 tests in `tests/test_tobit_loss.py`:
+- **Tests:** 28 tests in `tests/test_tobit_loss.py`:
   - Interface (5): importable, nn.Module, needs_latent flag, scalar output, sigma validation
   - Censored (4): all-censored, gradient direction, loss monotonicity, hand-computed
   - Observed (3): all-observed, perfect prediction, hand-computed
   - Mixed (3): batch, gradient density, spatial shapes
   - Numerical stability (4): large positive/negative mu, large residual, small sigma
   - Registry (4): registered, factory, config accepts, config rejects tobit+hurdle
-  - ModelOutput (4): field exists, forward returns it, pre-ReLU property, relu relationship
+  - ModelOutput (5): field exists, forward returns it, pre-ReLU property, relu relationship, eval-mode None
 
 - **Failure Mode:** If isolation test S2a-Tobit shows training loss oscillation similar to S2-hurdle, the normal latent assumption is inappropriate. Proceed to Path D (tail-aware extension).
 

--- a/docs/ADRs/proposed/054_tobit_censored_regression_loss.md
+++ b/docs/ADRs/proposed/054_tobit_censored_regression_loss.md
@@ -1,0 +1,99 @@
+# ADR-054: Tobit Censored-Normal Likelihood as Regression Loss
+
+**Status:** Proposed
+**Date:** 2026-05-29
+**Deciders:** Simon / Claude
+**Informed:** MD&D Team
+
+---
+
+## 1. Context
+**Why are we doing this now?**
+
+- **Problem:** The sweep isolation experiment (S2) demonstrated that the hurdle mask (`hurdle_threshold=0.0` in `training_engine.py:172-178`) causes gradient starvation. With ~95% of PRIO-Grid cells at zero, the regression head receives gradient from only ~5% of cells. This produces training non-convergence (oscillating loss 2300-4300 vs baseline's monotonic 1200->221) and autoregressive divergence during 36-step inference.
+
+- **Architectural observation:** The model's decoder heads apply `F.relu()` as the final activation (lines 432, 464, 496 in `HydraBNrecurrentUnet_06_LSTM4.py`). This is literally the Type-I Tobit observation equation: `y = max(0, z*)` where `z*` is the latent intensity. The architecture already implements left-censoring at zero. It is using the wrong loss function for the censoring model it already embodies.
+
+- **Urgency:** This is Step 1 of 6 in the zero-inflation instability remediation sequence (A -> E -> D/B -> C/F). All subsequent paths depend on stable baseline regression. Issue #36.
+
+---
+
+## 2. Decision
+**Replace the hurdle mask with Tobit censored-normal negative log-likelihood.**
+
+- **Statement:** We add `TobitLoss` to the loss registry as `loss_reg: 'tobit'`. When selected, the training engine uses pre-ReLU latent activations (`output.reg_latent`) for loss computation, providing dense gradient from ALL cells. Post-ReLU values continue to be used for autoregressive inference feedback and forensic recording.
+
+- **In-Scope:**
+  - `TobitLoss` class with fixed sigma parameter (`views_hydranet/utils/tobit_loss.py`)
+  - `ModelOutput.reg_latent` field exposing pre-ReLU activations
+  - Training engine wiring: `needs_latent` protocol for loss-model coupling
+  - Config validation: `loss_reg='tobit'` with `hurdle_threshold` raises `ValueError`
+
+- **Out-of-Scope:**
+  - Learned sigma (heteroscedastic Tobit) -- future refinement if fixed sigma proves sensitive
+  - Heckman selection correction for active-cell bias -- Path B (issue #37)
+  - Tail-aware extensions beyond normal latent -- Path D (issue #39)
+  - Autoregressive exposure bias mitigation -- Path E (issue #40)
+
+---
+
+## 3. Rationale & Integrity Impact
+**The logic behind the choice.**
+
+- **Logic:** The hurdle mask treats y=0 as "ignore this cell" (zero gradient). The baseline shrinkage loss treats y=0 as "predict zero" (full gradient). Tobit treats y=0 as "the latent intensity was <= 0, and we observed the censored value" (principled gradient). The censored-cell loss `-log Phi(-mu/sigma)` pushes the latent mu negative, teaching the model "this cell should be quiet" without discarding 95% of the training signal.
+
+- **Literature support:** Five independent groups validate deep Tobit:
+  - Zhang et al. (2021): DTN-I ReLU = Type-I Tobit. Outperforms standard DNNs.
+  - Danăilă & Buiu (2024): Reparametrized Tobit has globally concave log-likelihood.
+  - Jacobson & Zou (2024): MSE advantage grows with censoring proportion q. At q~0.95 the advantage is massive.
+  - Wu et al. (2026): Convergence rate and selection consistency guarantees.
+  - O'Neill (2024): TOBART confirms Tobit works with nonlinear function approximators.
+
+- **Fortress State:** The `needs_latent` protocol ensures the pre-ReLU/post-ReLU distinction is explicit and type-checked. Config validation prevents contradictory `tobit + hurdle_threshold` combinations. The `is True` check on `needs_latent` prevents MagicMock-induced bugs in test mocks.
+
+- **Fail-Loud:** Config validator raises `ValueError` if `loss_reg='tobit'` and `hurdle_threshold` is set simultaneously. `TobitLoss.__init__` raises on `sigma <= 0`.
+
+---
+
+## 4. Consequences
+**The honest trade-off.**
+
+### Positive
+- Dense gradient from ALL cells eliminates gradient starvation
+- Principled statistical treatment of zero-inflation (censoring, not masking)
+- ReLU + Tobit is a mathematically coherent model (Type-I Tobit)
+- Pre-ReLU latent exposure enables future work (Heckman correction, Path B)
+
+### Negative
+- Assumes normal latent distribution (conflict fatalities have power-law tails)
+- Fixed sigma is a hyperparameter; wrong value may require tuning
+- 4th field in `ModelOutput` breaks legacy `r, c, h = model(x, h)` tuple unpacking
+- Marginal memory increase from carrying `reg_latent` alongside `reg`
+
+---
+
+## 5. Validation
+**How do we prove it works?**
+
+- **Invariants:**
+  - `output.reg == F.relu(output.reg_latent)` (enforced by `test_relu_relationship`)
+  - `output.reg >= 0` always (enforced by `test_reg_latent_is_pre_relu`)
+  - Gradient flows to ALL cells including y=0 (enforced by `test_gradient_flows_to_all_cells`)
+
+- **Tests:** 27 tests in `tests/test_tobit_loss.py`:
+  - Interface (5): importable, nn.Module, needs_latent flag, scalar output, sigma validation
+  - Censored (4): all-censored, gradient direction, loss monotonicity, hand-computed
+  - Observed (3): all-observed, perfect prediction, hand-computed
+  - Mixed (3): batch, gradient density, spatial shapes
+  - Numerical stability (4): large positive/negative mu, large residual, small sigma
+  - Registry (4): registered, factory, config accepts, config rejects tobit+hurdle
+  - ModelOutput (4): field exists, forward returns it, pre-ReLU property, relu relationship
+
+- **Failure Mode:** If isolation test S2a-Tobit shows training loss oscillation similar to S2-hurdle, the normal latent assumption is inappropriate. Proceed to Path D (tail-aware extension).
+
+---
+
+## 6. Implementation Notes
+- **Location:** `views_hydranet/utils/tobit_loss.py`, `ModelOutput` in architecture file, `LOSS_REG_REGISTRY` in `utils.py`, training engine latent wiring, config validator in `config_initializer.py`.
+- **References:** Issue #36, ADR-050 (superseded for the hurdle approach), `reports/paths_forward.md`.
+- **sigma handling roadmap:** Fixed sigma=1.0 (this ADR) -> learned scalar sigma -> reparametrized gamma=1/sigma (Danăilă 2024) -> heteroscedastic sigma(x). Each step is a separate config option; no architectural change needed.

--- a/docs/CICs/HydraNetConfig.md
+++ b/docs/CICs/HydraNetConfig.md
@@ -3,7 +3,7 @@
 **Status:** Active
 **Owner:** Schema
 **Last reviewed:** 26.05.2026
-**Related ADRs:** ADR-009, ADR-046, ADR-049, ADR-050
+**Related ADRs:** ADR-009, ADR-046, ADR-049, ADR-050, ADR-054
 
 ---
 
@@ -55,7 +55,7 @@ The `HydraNetConfig` is the **Schema** of the HydraNet pipeline. Its primary pur
 - **Invalid Evaluation Mode:** Raises `ValueError` with valid options listed — no silent typo correction for `evaluation_mode` (only the legacy `evalution_mode` key name is corrected).
 - **Invalid Loss Function (Regression):** Raises `ValueError` when `loss_reg` is not in `LOSS_REG_REGISTRY`, listing valid options.
 - **Invalid Loss Function (Classification):** Raises `ValueError` when `loss_class` is not in `LOSS_CLASS_REGISTRY`, listing valid options.
-- **Missing Loss Reg Parameter:** Raises `ValueError` when the active regression loss's required parameter is not provided (e.g., `shrinkage` requires `loss_reg_a` and `loss_reg_c`, `basu_dpd` requires `loss_reg_alpha` and `loss_reg_sigma`).
+- **Missing Loss Reg Parameter:** Raises `ValueError` when the active regression loss's required parameter is not provided (e.g., `shrinkage` requires `loss_reg_a` and `loss_reg_c`, `basu_dpd` requires `loss_reg_alpha` and `loss_reg_sigma`, `tobit` requires `loss_reg_sigma`).
 - **Missing Loss Class Parameter:** Raises `ValueError` when the active classification loss's required parameter is not provided (e.g., `focal` requires `loss_class_alpha` and `loss_class_gamma`).
 - **Invalid Aggregate Method:** Raises `ValueError` when `aggregate_method` is not in `[arithmetic_mean, geometric_mean, median]`.
 - **Degenerate Slope Ratio:** Raises `ValueError` when `slope_ratio <= 0.0` (causes division-by-zero in curriculum).
@@ -65,6 +65,7 @@ The `HydraNetConfig` is the **Schema** of the HydraNet pipeline. Its primary pur
 - **Invalid Sampling Strategy (ADR-049):** Raises `ValueError` when `sampling_strategy` is not in `SAMPLING_STRATEGY_REGISTRY`, listing valid options.
 - **Missing Sampling Strategy:** Raises `ValidationError` — `sampling_strategy` is a required field with no default.
 - **Missing Strategy Parameter (ADR-049):** Raises `ValueError` when the strategy's required parameter is not provided (e.g., `power_law` requires `sampling_alpha`, `boltzmann` requires `sampling_temperature`, `sigmoid` requires `sampling_steepness`).
+- **Contradictory Tobit + Hurdle (ADR-054):** Raises `ValueError` when `loss_reg='tobit'` and `hurdle_threshold` is set. Tobit handles zero-inflation internally via censored likelihood; the hurdle mask is contradictory.
 - **Missing Hurdle QS99 Parameter (ADR-050):** Raises `ValueError` when `hurdle_threshold` is set with `qs99_weight > 0` but `qs99_tau` is not provided.
 - **Invalid QS99 Weight (ADR-050):** Raises `ValidationError` when `qs99_weight < 0` (negative weight inverts the penalty direction).
 - **Invalid QS99 Tau (ADR-050):** Raises `ValidationError` when `qs99_tau` is not in `(0.0, 1.0)` (pinball loss quantile must be a valid probability).
@@ -105,7 +106,7 @@ all_keys = config_obj.keys()
 
 ## 10. Test Alignment
 
-- **🟩 Green Team:** Valid configuration construction and dict access in `tests/test_config_typed.py`. Hurdle+Basu DPD integration paths in `tests/test_hurdle_basu_integration.py`.
+- **🟩 Green Team:** Valid configuration construction and dict access in `tests/test_config_typed.py`. Hurdle+Basu DPD integration paths in `tests/test_hurdle_basu_integration.py`. Tobit config acceptance and tobit+hurdle rejection in `tests/test_tobit_loss.py`.
 - **🟫 Beige Team:** Checksum violations, lifecycle law, stochastic mode warning in `tests/test_config_validation.py`. Config path guards (hurdle disabled, qs99_weight=0) in `tests/test_hurdle_basu_integration.py`.
 - **🟥 Red Team:** Invalid run_type, evaluation_mode, hidden channels divisibility, missing fields in `tests/test_config_validation.py`. QS99 range validation, Basu degenerate params in `tests/test_falsification_hurdle_params.py`. Hurdle parameter enforcement, target_weights validation in `tests/test_hurdle_basu_integration.py`. CIC field count drift in `tests/test_falsification_loss_param_validation.py`.
 

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -4,9 +4,9 @@
 |-------------------|--------------------------------------|
 | Project           | views-hydranet                       |
 | Owner             | Simon Polichinel von der Maase       |
-| Last Updated      | 2026-05-28                           |
-| Total Concerns    | 92                                   |
-| Open Concerns     | 15                                   |
+| Last Updated      | 2026-05-29                           |
+| Total Concerns    | 93                                   |
+| Open Concerns     | 16                                   |
 | Resolved Concerns | 77                                   |
 
 ---
@@ -282,6 +282,22 @@ Tier 4 rationale: code quality / DRY violation. Single-developer scope. No corre
 `HydranetManager` implements `_evaluate_model_artifact` (single runs) but not `_evaluate_sweep` (wandb sweeps). The base class `ForecastingModelManager` marks it `@abstractmethod`. Root cause: `_setup_evaluation()` (lines 224-314) couples model loading (lines 268-279) with data pipeline + orchestrator wiring (lines 281-314). Sweep needs the data pipeline but not the disk load — the model is in-memory. Fix requires decomposing `_setup_evaluation()`: extract model loading into `_load_model_artifact()`, make `model` a required parameter of `_setup_evaluation()`, then add a 5-line `_evaluate_sweep()` override. Sibling managers (views-baseline, views-stepshifter) implement this method; HydraNet is the only one missing it.
 
 Tier 2 rationale: structural fragility — every sweep run crashes today. Clear trigger. Blocks hyperparameter optimization workflow.
+
+---
+
+### C-94: `reg_latent` tensor allocated during inference — wasteful memory
+
+| Field | Value |
+|-------|-------|
+| ID | C-94 |
+| Tier | 4 |
+| Source | pr-review (2026-05-29) |
+| Trigger | When running long autoregressive inference (36 steps × many origins), verify `reg_latent` is not consuming unnecessary GPU memory per step |
+| Location | `views_hydranet/architectures/HydraBNrecurrentUnet_06_LSTM4.py` (`forward()`) |
+
+`ModelOutput.reg_latent` carries the pre-ReLU latent activations needed by `TobitLoss` during training. However, `forward()` always populates `reg_latent` regardless of whether the model is in training or eval mode. During inference (`model.eval()`), `reg_latent` is never consumed — the training engine uses it only inside the training loop. Each inference step allocates a full `[B, C, H, W]` tensor that is immediately discarded. Over 36 autoregressive steps × multiple origins, this is wasteful. Fix: gate `reg_latent` population on `self.training`.
+
+See also C-22 (resolved — ModelOutput NamedTuple), ADR-054 (Tobit loss).
 
 ---
 

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -6,8 +6,8 @@
 | Owner             | Simon Polichinel von der Maase       |
 | Last Updated      | 2026-05-29                           |
 | Total Concerns    | 93                                   |
-| Open Concerns     | 16                                   |
-| Resolved Concerns | 77                                   |
+| Open Concerns     | 15                                   |
+| Resolved Concerns | 78                                   |
 
 ---
 
@@ -285,22 +285,6 @@ Tier 2 rationale: structural fragility — every sweep run crashes today. Clear 
 
 ---
 
-### C-94: `reg_latent` tensor allocated during inference — wasteful memory
-
-| Field | Value |
-|-------|-------|
-| ID | C-94 |
-| Tier | 4 |
-| Source | pr-review (2026-05-29) |
-| Trigger | When running long autoregressive inference (36 steps × many origins), verify `reg_latent` is not consuming unnecessary GPU memory per step |
-| Location | `views_hydranet/architectures/HydraBNrecurrentUnet_06_LSTM4.py` (`forward()`) |
-
-`ModelOutput.reg_latent` carries the pre-ReLU latent activations needed by `TobitLoss` during training. However, `forward()` always populates `reg_latent` regardless of whether the model is in training or eval mode. During inference (`model.eval()`), `reg_latent` is never consumed — the training engine uses it only inside the training loop. Each inference step allocates a full `[B, C, H, W]` tensor that is immediately discarded. Over 36 autoregressive steps × multiple origins, this is wasteful. Fix: gate `reg_latent` population on `self.training`.
-
-See also C-22 (resolved — ModelOutput NamedTuple), ADR-054 (Tobit loss).
-
----
-
 ## Disagreements
 
 ### D-01: VolumeHandler scope — God Object vs Deep Module
@@ -348,6 +332,16 @@ See also C-22 (resolved — ModelOutput NamedTuple), ADR-054 (Tobit loss).
 ---
 
 ## Resolved Concerns
+
+### C-94: `reg_latent` tensor allocated during inference — wasteful memory — RESOLVED
+
+| Field | Value |
+|-------|-------|
+| ID | C-94 |
+| Resolved | 2026-05-29 |
+| Resolution | Gated `out_reg_latent` concatenation on `self.training` in `forward()`. Eval mode now returns `reg_latent=None`, eliminating one `[B, C, H, W]` allocation per autoregressive step. Verified by `test_reg_latent_none_in_eval_mode`. |
+
+---
 
 ### C-88: No integration test for `target_weights` multi-target application — RESOLVED
 

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -39,12 +39,13 @@ def test_architecture_forward_pass_shapes():
     x = torch.randn((1, input_ch, H, W)).float()
     h = model.init_hTtime(hidden_ch, H, W).float()
 
-    out_reg, out_class, new_h = model(x, h)
+    output = model(x, h)
 
     # 3 heads (sb, ns, os) concatenated
-    assert out_reg.shape == (1, 3, H, W)
-    assert out_class.shape == (1, 3, H, W)
-    assert new_h.shape == (1, hidden_ch, H, W)
+    assert output.reg.shape == (1, 3, H, W)
+    assert output.cls.shape == (1, 3, H, W)
+    assert output.h_next.shape == (1, hidden_ch, H, W)
+    assert output.reg_latent.shape == (1, 3, H, W)
 
 
 def test_architecture_recurrent_state_evolution():
@@ -53,11 +54,11 @@ def test_architecture_recurrent_state_evolution():
     x = torch.randn((1, 8, 16, 16)).float()
     h_init = model.init_hTtime(32, 16, 16).float()
 
-    _, _, h_next = model(x, h_init)
+    output = model(x, h_init)
 
     # Hidden state should no longer be zeros
-    assert not torch.all(h_next == 0)
-    assert h_next.shape == h_init.shape
+    assert not torch.all(output.h_next == 0)
+    assert output.h_next.shape == h_init.shape
 
 
 def test_architecture_multi_batch_support():
@@ -73,12 +74,14 @@ def test_architecture_multi_batch_support():
     x = torch.randn((batch_size, input_ch, H, W)).float()
     h = torch.zeros((batch_size, hidden_ch, H, W)).float()
 
-    out_reg, out_class, new_h = model(x, h)
+    output = model(x, h)
 
-    assert out_reg.shape[0] == batch_size, (
-        f"Expected batch dim {batch_size}, got {out_reg.shape[0]}"
+    assert output.reg.shape[0] == batch_size, (
+        f"Expected batch dim {batch_size}, got {output.reg.shape[0]}"
     )
-    assert new_h.shape[0] == batch_size, f"Expected batch dim {batch_size}, got {new_h.shape[0]}"
+    assert output.h_next.shape[0] == batch_size, (
+        f"Expected batch dim {batch_size}, got {output.h_next.shape[0]}"
+    )
 
 
 def test_weight_init_xavier_norm_is_not_silent():

--- a/tests/test_tobit_loss.py
+++ b/tests/test_tobit_loss.py
@@ -364,3 +364,18 @@ class TestModelOutputRegLatent:
         assert torch.allclose(output.reg, expected, atol=1e-6), (
             "reg should equal F.relu(reg_latent)"
         )
+
+    def test_reg_latent_none_in_eval_mode(self):
+        """reg_latent should be None when model is in eval mode (saves memory)."""
+        from views_hydranet.architectures.HydraBNrecurrentUnet_06_LSTM4 import (
+            HydraBNUNet06_LSTM4,
+        )
+
+        model = HydraBNUNet06_LSTM4(8, 32, 1, 0.0).float()
+        model.eval()
+        x = torch.randn(1, 8, 16, 16).float()
+        h = model.init_hTtime(32, 16, 16).float()
+        output = model(x, h)
+
+        assert output.reg_latent is None
+        assert output.reg is not None

--- a/tests/test_tobit_loss.py
+++ b/tests/test_tobit_loss.py
@@ -1,0 +1,366 @@
+"""
+Tests for TobitLoss — Type-I Tobit censored-normal likelihood.
+
+Tobin (1958): y = max(0, z*) where z* ~ N(mu, sigma^2).
+The model's ReLU output is literally this observation equation (Zhang 2021).
+This loss provides dense gradient from ALL cells including y=0 (censored),
+replacing the gradient-starving hurdle mask.
+"""
+
+import math
+
+import pytest
+import torch
+
+from views_hydranet.utils.tobit_loss import TobitLoss
+
+
+class TestTobitLossInterface:
+    """Module interface and basic contract tests."""
+
+    def test_importable(self):
+        from views_hydranet.utils.tobit_loss import TobitLoss  # noqa: F401
+
+    def test_is_nn_module(self):
+        loss = TobitLoss(sigma=1.0)
+        assert isinstance(loss, torch.nn.Module)
+
+    def test_has_needs_latent_flag(self):
+        loss = TobitLoss(sigma=1.0)
+        assert loss.needs_latent is True
+
+    def test_forward_returns_scalar(self):
+        loss_fn = TobitLoss(sigma=1.0)
+        pred = torch.randn(1, 4, 4, requires_grad=True)
+        target = torch.abs(torch.randn(1, 4, 4))
+        result = loss_fn(pred, target)
+        assert result.ndim == 0, f"Expected scalar, got shape {result.shape}"
+        assert result.requires_grad
+
+    def test_sigma_must_be_positive(self):
+        with pytest.raises(ValueError, match="sigma must be > 0"):
+            TobitLoss(sigma=0.0)
+        with pytest.raises(ValueError, match="sigma must be > 0"):
+            TobitLoss(sigma=-1.0)
+
+
+class TestTobitLossCensored:
+    """Censored cells (y=0): -log Phi(-mu/sigma)."""
+
+    def test_all_censored(self):
+        loss_fn = TobitLoss(sigma=1.0)
+        mu = torch.tensor([-2.0, -1.0, 0.0, 1.0], requires_grad=True)
+        target = torch.zeros(4)
+        loss = loss_fn(mu, target)
+        assert loss.isfinite()
+        loss.backward()
+        assert mu.grad is not None
+        assert mu.grad.isfinite().all()
+
+    def test_censored_gradient_pushes_mu_negative(self):
+        """For y=0, gradient of -log Phi(-mu/sigma) w.r.t. mu is positive,
+        meaning gradient descent pushes mu toward more negative values."""
+        loss_fn = TobitLoss(sigma=1.0)
+        mu = torch.tensor([1.0], requires_grad=True)
+        target = torch.zeros(1)
+        loss = loss_fn(mu, target)
+        loss.backward()
+        assert mu.grad > 0, (
+            f"Gradient should be positive (push mu negative via descent), got {mu.grad.item()}"
+        )
+
+    def test_censored_loss_increases_with_positive_mu(self):
+        """Larger positive mu should give larger loss for censored cells."""
+        loss_fn = TobitLoss(sigma=1.0)
+        target = torch.zeros(1)
+
+        mu_neg = torch.tensor([-2.0])
+        mu_pos = torch.tensor([2.0])
+
+        loss_neg = loss_fn(mu_neg, target)
+        loss_pos = loss_fn(mu_pos, target)
+
+        assert loss_pos > loss_neg, (
+            f"Loss for mu=2 ({loss_pos.item():.4f}) should exceed "
+            f"loss for mu=-2 ({loss_neg.item():.4f}) when y=0"
+        )
+
+    def test_censored_hand_computed(self):
+        """Verify against hand-computed -log Phi(-mu/sigma) for sigma=1."""
+        loss_fn = TobitLoss(sigma=1.0)
+        mu = torch.tensor([0.0])
+        target = torch.zeros(1)
+        loss = loss_fn(mu, target)
+        expected = -math.log(0.5)  # Phi(0) = 0.5
+        assert abs(loss.item() - expected) < 1e-5, (
+            f"Expected {expected:.5f}, got {loss.item():.5f}"
+        )
+
+
+class TestTobitLossObserved:
+    """Observed cells (y>0): 0.5 * ((y-mu)/sigma)^2 + log(sigma)."""
+
+    def test_all_observed(self):
+        loss_fn = TobitLoss(sigma=1.0)
+        mu = torch.randn(4, requires_grad=True)
+        target = torch.abs(torch.randn(4)) + 0.1
+        loss = loss_fn(mu, target)
+        assert loss.isfinite()
+        loss.backward()
+        assert mu.grad is not None
+        assert mu.grad.isfinite().all()
+
+    def test_perfect_prediction_loss(self):
+        """At mu=y with sigma=1, observed loss is 0.5*0 + log(1) = 0."""
+        loss_fn = TobitLoss(sigma=1.0)
+        target = torch.tensor([1.0, 2.0, 3.0])
+        mu = target.clone()
+        loss = loss_fn(mu, target)
+        assert abs(loss.item()) < 1e-6
+
+    def test_observed_hand_computed(self):
+        """Verify observed NLL for known values."""
+        loss_fn = TobitLoss(sigma=2.0)
+        mu = torch.tensor([1.0])
+        target = torch.tensor([3.0])
+        loss = loss_fn(mu, target)
+        expected = 0.5 * ((3.0 - 1.0) / 2.0) ** 2 + math.log(2.0)
+        assert abs(loss.item() - expected) < 1e-5, (
+            f"Expected {expected:.5f}, got {loss.item():.5f}"
+        )
+
+
+class TestTobitLossMixed:
+    """Mixed censored + observed cells (the typical case: ~95% zeros)."""
+
+    def test_mixed_batch(self):
+        loss_fn = TobitLoss(sigma=1.0)
+        mu = torch.randn(100, requires_grad=True)
+        target = torch.zeros(100)
+        target[:5] = torch.abs(torch.randn(5)) + 0.1
+        loss = loss_fn(mu, target)
+        assert loss.isfinite()
+        loss.backward()
+        assert mu.grad is not None
+        assert mu.grad.isfinite().all()
+
+    def test_gradient_flows_to_all_cells(self):
+        """Unlike the hurdle mask, Tobit provides gradient to every cell."""
+        loss_fn = TobitLoss(sigma=1.0)
+        mu = torch.randn(10, requires_grad=True)
+        target = torch.zeros(10)
+        target[0] = 1.5
+        loss = loss_fn(mu, target)
+        loss.backward()
+        assert (mu.grad != 0).all(), (
+            f"All cells should receive gradient. Zero-grad cells: {(mu.grad == 0).sum().item()}/10"
+        )
+
+    def test_spatial_tensor_shape(self):
+        """Must work with [B, H, W] spatial tensors (per-head slice)."""
+        loss_fn = TobitLoss(sigma=1.0)
+        mu = torch.randn(2, 8, 8, requires_grad=True)
+        target = torch.zeros(2, 8, 8)
+        target[0, 0, 0] = 2.0
+        target[1, 3, 5] = 1.0
+        loss = loss_fn(mu, target)
+        assert loss.isfinite()
+        loss.backward()
+        assert mu.grad.isfinite().all()
+
+
+class TestTobitLossNumericalStability:
+    """Edge cases that could cause NaN/Inf."""
+
+    def test_large_positive_mu_censored(self):
+        """Large positive mu with y=0: high loss but finite."""
+        loss_fn = TobitLoss(sigma=1.0)
+        mu = torch.tensor([50.0], requires_grad=True)
+        target = torch.zeros(1)
+        loss = loss_fn(mu, target)
+        assert loss.isfinite(), f"Loss is {loss.item()} for mu=50, y=0"
+        loss.backward()
+        assert mu.grad.isfinite().all()
+
+    def test_large_negative_mu_censored(self):
+        """Large negative mu with y=0: near-zero loss."""
+        loss_fn = TobitLoss(sigma=1.0)
+        mu = torch.tensor([-50.0], requires_grad=True)
+        target = torch.zeros(1)
+        loss = loss_fn(mu, target)
+        assert loss.isfinite(), f"Loss is {loss.item()} for mu=-50, y=0"
+        assert loss.item() < 1e-6
+
+    def test_large_residual_observed(self):
+        """Large prediction error for observed cells."""
+        loss_fn = TobitLoss(sigma=1.0)
+        mu = torch.tensor([100.0], requires_grad=True)
+        target = torch.tensor([0.1])
+        loss = loss_fn(mu, target)
+        assert loss.isfinite()
+        loss.backward()
+        assert mu.grad.isfinite().all()
+
+    def test_small_sigma(self):
+        """Small sigma should work without overflow."""
+        loss_fn = TobitLoss(sigma=0.1)
+        mu = torch.randn(10, requires_grad=True)
+        target = torch.zeros(10)
+        target[:2] = torch.tensor([0.5, 1.0])
+        loss = loss_fn(mu, target)
+        assert loss.isfinite()
+        loss.backward()
+        assert mu.grad.isfinite().all()
+
+
+def _tobit_config(**overrides):
+    """Minimal valid kwargs for HydraNetConfig with Tobit loss."""
+    base = {
+        "run_type": "calibration",
+        "features": ["lr_sb", "by_sb"],
+        "regression_targets": ["lr_sb"],
+        "classification_targets": ["by_sb"],
+        "height": 8,
+        "width": 8,
+        "index_names": ["month_id", "priogrid_gid"],
+        "time_col": "month_id",
+        "id_col": "priogrid_gid",
+        "spatial_cols": ["row", "col"],
+        "row_offset": 0,
+        "col_offset": 0,
+        "model": "HydraBNUNet06_LSTM4",
+        "window_dim": 4,
+        "total_hidden_channels": 16,
+        "dropout_rate": 0.1,
+        "weight_init": "xavier_norm",
+        "learning_rate": 0.001,
+        "weight_decay": 0.01,
+        "windows_per_lesson": 2,
+        "scheduler": "plateau",
+        "warmup_steps": 5,
+        "clip_grad_norm": True,
+        "loss_reg": "tobit",
+        "loss_reg_sigma": 1.0,
+        "loss_class": "bce",
+        "total_lessons": 10,
+        "n_posterior_samples": 5,
+        "np_seed": 42,
+        "torch_seed": 42,
+        "min_events": 0,
+        "slope_ratio": 1.0,
+        "roof_ratio": 1.0,
+        "max_ratio": 0.9,
+        "min_ratio": 0.1,
+        "freeze_h": "none",
+        "sampling_strategy": "threshold",
+        "evaluation_mode": "point",
+        "aggregate_method": "arithmetic_mean",
+        "prediction_format": "prediction_frame",
+        "time_steps": 3,
+        "steps": [1, 2, 3],
+        "input_channels": 2,
+        "output_channels": 2,
+        "identity_cols": ["priogrid_gid", "month_id"],
+        "transformations": {"log1p": ["lr_sb", "by_sb"]},
+    }
+    base.update(overrides)
+    return base
+
+
+class TestTobitLossRegistry:
+    """Integration with the loss registry."""
+
+    def test_registered_in_loss_reg_registry(self):
+        from views_hydranet.utils.utils import LOSS_REG_REGISTRY
+
+        assert "tobit" in LOSS_REG_REGISTRY
+
+    def test_factory_creates_instance(self):
+        from views_hydranet.utils.utils import LOSS_REG_REGISTRY
+
+        config = {"loss_reg_sigma": 1.0}
+        device = torch.device("cpu")
+        loss = LOSS_REG_REGISTRY["tobit"]["factory"](config, device)
+        assert isinstance(loss, TobitLoss)
+        assert loss.sigma == 1.0
+
+    def test_config_validator_accepts_tobit(self):
+        from views_hydranet.utils.config_initializer import HydraNetConfig
+
+        config = HydraNetConfig(**_tobit_config())
+        assert config.loss_reg == "tobit"
+
+    def test_config_rejects_tobit_with_hurdle(self):
+        from views_hydranet.utils.config_initializer import HydraNetConfig
+
+        with pytest.raises(ValueError, match="contradictory"):
+            HydraNetConfig(**_tobit_config(hurdle_threshold=0.0))
+
+
+class TestModelOutputRegLatent:
+    """Verify the pre-ReLU latent is exposed by ModelOutput."""
+
+    def test_model_output_has_reg_latent_field(self):
+        from views_hydranet.architectures.HydraBNrecurrentUnet_06_LSTM4 import (
+            ModelOutput,
+        )
+
+        output = ModelOutput(
+            reg=torch.zeros(1),
+            cls=torch.zeros(1),
+            h_next=torch.zeros(1),
+        )
+        assert output.reg_latent is None
+
+        output_with_latent = ModelOutput(
+            reg=torch.zeros(1),
+            cls=torch.zeros(1),
+            h_next=torch.zeros(1),
+            reg_latent=torch.ones(1),
+        )
+        assert output_with_latent.reg_latent is not None
+
+    def test_model_forward_returns_reg_latent(self):
+        from views_hydranet.architectures.HydraBNrecurrentUnet_06_LSTM4 import (
+            HydraBNUNet06_LSTM4,
+        )
+
+        model = HydraBNUNet06_LSTM4(8, 32, 1, 0.1).float()
+        x = torch.randn(1, 8, 16, 16).float()
+        h = model.init_hTtime(32, 16, 16).float()
+        output = model(x, h)
+
+        assert output.reg_latent is not None
+        assert output.reg_latent.shape == output.reg.shape
+
+    def test_reg_latent_is_pre_relu(self):
+        """reg_latent can be negative; reg (post-ReLU) cannot."""
+        from views_hydranet.architectures.HydraBNrecurrentUnet_06_LSTM4 import (
+            HydraBNUNet06_LSTM4,
+        )
+
+        torch.manual_seed(42)
+        model = HydraBNUNet06_LSTM4(8, 32, 1, 0.0).float()
+        x = torch.randn(1, 8, 16, 16).float()
+        h = model.init_hTtime(32, 16, 16).float()
+        output = model(x, h)
+
+        assert (output.reg >= 0).all(), "Post-ReLU should be non-negative"
+        assert (output.reg_latent < 0).any(), "Pre-ReLU latent should contain negative values"
+
+    def test_relu_relationship(self):
+        """reg should equal relu(reg_latent)."""
+        from views_hydranet.architectures.HydraBNrecurrentUnet_06_LSTM4 import (
+            HydraBNUNet06_LSTM4,
+        )
+
+        torch.manual_seed(42)
+        model = HydraBNUNet06_LSTM4(8, 32, 1, 0.0).float()
+        x = torch.randn(1, 8, 16, 16).float()
+        h = model.init_hTtime(32, 16, 16).float()
+        output = model(x, h)
+
+        expected = torch.relu(output.reg_latent)
+        assert torch.allclose(output.reg, expected, atol=1e-6), (
+            "reg should equal F.relu(reg_latent)"
+        )

--- a/views_hydranet/architectures/HydraBNrecurrentUnet_06_LSTM4.py
+++ b/views_hydranet/architectures/HydraBNrecurrentUnet_06_LSTM4.py
@@ -9,14 +9,19 @@ class ModelOutput(NamedTuple):
     """
     Typed return value for HydraBNUNet06_LSTM4.forward().
 
-    Replaces the implicit (out_reg, out_class, h) tuple with named fields,
-    eliminating cast(Any, model) at consumer sites (C-22). NamedTuple supports
-    tuple unpacking, so legacy `r, c, h = model(x, h)` continues to work.
+    Fields reg, cls, h_next are the primary outputs. reg_latent carries the
+    pre-ReLU regression activations needed by censored losses (TobitLoss).
+    Consumers that do not need latent values can ignore it — default is None.
+
+    NOTE: Adding reg_latent as a 4th field means tuple unpacking with 3
+    variables (``r, c, h = model(x, h)``) no longer works. Use named access:
+    ``output.reg, output.cls, output.h_next``.
     """
 
-    reg: torch.Tensor  # [B, n_reg, H, W] regression head outputs
+    reg: torch.Tensor  # [B, n_reg, H, W] post-ReLU regression head outputs
     cls: torch.Tensor  # [B, n_cls, H, W] classification head logits
     h_next: torch.Tensor  # [B, total_hidden_channels, H, W] LSTM hidden state
+    reg_latent: torch.Tensor | None = None  # [B, n_reg, H, W] pre-ReLU latent mu
 
 
 # give everything better names at some point
@@ -511,10 +516,11 @@ class HydraBNUNet06_LSTM4(nn.Module):
         H3_class = self.dec_conv4_head3_class(H3_class)
         out_class3 = H3_class
 
+        out_reg_latent = torch.concat([H1_reg, H2_reg, H3_reg], dim=1)
         out_reg = torch.concat([out_reg1, out_reg2, out_reg3], dim=1)
         out_class = torch.concat([out_class1, out_class2, out_class3], dim=1)
 
-        return ModelOutput(reg=out_reg, cls=out_class, h_next=h)
+        return ModelOutput(reg=out_reg, cls=out_class, h_next=h, reg_latent=out_reg_latent)
 
     def init_hTtime(self, hidden_channels, H, W):
         """

--- a/views_hydranet/architectures/HydraBNrecurrentUnet_06_LSTM4.py
+++ b/views_hydranet/architectures/HydraBNrecurrentUnet_06_LSTM4.py
@@ -516,7 +516,7 @@ class HydraBNUNet06_LSTM4(nn.Module):
         H3_class = self.dec_conv4_head3_class(H3_class)
         out_class3 = H3_class
 
-        out_reg_latent = torch.concat([H1_reg, H2_reg, H3_reg], dim=1)
+        out_reg_latent = torch.concat([H1_reg, H2_reg, H3_reg], dim=1) if self.training else None
         out_reg = torch.concat([out_reg1, out_reg2, out_reg3], dim=1)
         out_class = torch.concat([out_class1, out_class2, out_class3], dim=1)
 

--- a/views_hydranet/train/training_engine.py
+++ b/views_hydranet/train/training_engine.py
@@ -146,6 +146,10 @@ def _process_sequence(
         output = model(t0_input, h)
         t1_pred, t1_pred_class, h = output.reg, output.cls, output.h_next
 
+        # Censored losses (TobitLoss) need pre-ReLU latent mu
+        use_latent = getattr(criterion_reg, "needs_latent", False) is True
+        t1_pred_for_loss = output.reg_latent if use_latent else t1_pred
+
         # --- FORENSIC RECORDING (ADR 001 Custodian) ---
         if forensics:
             for j, target_name in enumerate(idx.reg_names):
@@ -161,7 +165,7 @@ def _process_sequence(
         losses_list = []
         qs99_loss = torch.tensor(0.0, device=device)
         for j in range(idx.n_reg):
-            pred_j = t1_pred[:, j, :, :]
+            pred_j = t1_pred_for_loss[:, j, :, :]
             target_j = y_reg[:, j, :, :]
 
             # C-87: per-target loss weight (1.0 if not configured)
@@ -169,7 +173,7 @@ def _process_sequence(
             if target_weights is not None:
                 tw = target_weights[idx.reg_names[j]]
 
-            if hurdle_threshold is not None:
+            if hurdle_threshold is not None and not use_latent:
                 # C-45: Regression loss on positive observations only
                 mask = target_j > hurdle_threshold
                 if mask.any():

--- a/views_hydranet/utils/config_initializer.py
+++ b/views_hydranet/utils/config_initializer.py
@@ -76,7 +76,7 @@ class HydraNetConfig(BaseModel):
     warmup_steps: int = Field(..., ge=1)
     clip_grad_norm: bool = Field(...)
 
-    # 6. Loss Functions (names: mse, shrinkage, basu_dpd, lognormal_nll)
+    # 6. Loss Functions (names: mse, shrinkage, basu_dpd, lognormal_nll, tobit)
     loss_reg: str = Field(...)
     loss_class: str = Field(...)
     # ShrinkageLoss params (loss_reg='shrinkage')
@@ -84,7 +84,7 @@ class HydraNetConfig(BaseModel):
     loss_reg_c: float | None = Field(default=None)
     # BasuDPDLoss params (loss_reg='basu_dpd')
     loss_reg_alpha: float | None = Field(default=None)
-    # Shared: BasuDPDLoss sigma / LogNormalFixedSigmaLoss sigma
+    # Shared: BasuDPDLoss / LogNormalFixedSigmaLoss / TobitLoss sigma
     loss_reg_sigma: float | None = Field(default=None)
     # ParetoLoss params (loss_reg='pareto')
     loss_reg_pareto_alpha: float | None = Field(default=None)
@@ -478,6 +478,14 @@ class HydraNetConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_hurdle_params(self) -> "HydraNetConfig":
+        if self.loss_reg == "tobit" and self.hurdle_threshold is not None:
+            err_msg = (
+                "loss_reg='tobit' handles zero-inflation internally via "
+                "censored likelihood. Setting hurdle_threshold is contradictory "
+                "— remove hurdle_threshold from your config."
+            )
+            logger.error(err_msg)
+            raise ValueError(err_msg)
         if (
             self.hurdle_threshold is not None
             and self.qs99_weight is not None

--- a/views_hydranet/utils/hydranet_inference.py
+++ b/views_hydranet/utils/hydranet_inference.py
@@ -120,7 +120,8 @@ class HydraNetInference:
             _, hl_t_frozen = torch.split(h_tt, split_size, dim=1)
 
             # Run the model
-            t1_pred, t1_pred_class, h_tt = self.model(t0, h_tt)
+            output = self.model(t0, h_tt)
+            t1_pred, t1_pred_class, h_tt = output.reg, output.cls, output.h_next
 
             # Split the updated hidden state and keep the old `hl_t_frozen`
             hs_t_updated, _ = torch.split(h_tt, split_size, dim=1)
@@ -135,7 +136,8 @@ class HydraNetInference:
             hs_t_frozen, _ = torch.split(h_tt, split_size, dim=1)
 
             # Run the model
-            t1_pred, t1_pred_class, h_tt = self.model(t0, h_tt)
+            output = self.model(t0, h_tt)
+            t1_pred, t1_pred_class, h_tt = output.reg, output.cls, output.h_next
 
             # Split the new hidden state and retain the frozen `hs_t_frozen`
             _, hl_t_updated = torch.split(h_tt, split_size, dim=1)
@@ -145,17 +147,20 @@ class HydraNetInference:
 
         elif freeze_h == "all":  # Freeze both short-term and long-term memory
             logger.debug("Freezing both hs and hl.")
-            t1_pred, t1_pred_class, _ = self.model(t0, h_tt)  # Do not update h_tt
+            output = self.model(t0, h_tt)
+            t1_pred, t1_pred_class = output.reg, output.cls  # Do not update h_tt
 
         elif freeze_h == "none":  # No freezing, use normal hidden state update
             logger.debug("Not freezing any memory.")
-            t1_pred, t1_pred_class, h_tt = self.model(t0, h_tt)
+            output = self.model(t0, h_tt)
+            t1_pred, t1_pred_class, h_tt = output.reg, output.cls, output.h_next
 
         elif freeze_h == "random":  # Randomly freeze some parts
             logger.debug("Random freezing mode activated.")
 
             # Run model first to get new `h_tt_new`
-            t1_pred, t1_pred_class, h_tt_new = self.model(t0, h_tt)
+            output = self.model(t0, h_tt)
+            t1_pred, t1_pred_class, h_tt_new = output.reg, output.cls, output.h_next
 
             # Vectorized Chunk Selection (ADR 028 Performance Hardening)
             num_chunks = self._RANDOM_FREEZE_NUM_CHUNKS

--- a/views_hydranet/utils/tobit_loss.py
+++ b/views_hydranet/utils/tobit_loss.py
@@ -1,0 +1,103 @@
+"""
+Tobit Censored-Normal Likelihood Loss for Regression Heads.
+
+Implements the Type-I Tobit model likelihood from:
+
+    Tobin, J. (1958). "Estimation of Relationships for Limited Dependent
+    Variables." Econometrica, 26(1), 24-36.
+
+The model's ReLU output activation (F.relu in decoder heads) is literally
+the Type-I Tobit observation equation: y = max(0, z*) where z* is the
+latent intensity. This loss uses the correct censored-normal likelihood
+instead of treating y=0 as "ignore" (hurdle mask) or "predict zero" (MSE).
+
+For a censored observation (y=0), the contribution is -log Phi(-mu/sigma),
+where Phi is the standard normal CDF. This provides dense gradient from
+ALL cells: the model learns "this cell should be quiet" (push mu negative)
+rather than receiving zero gradient (hurdle mask).
+
+For an observed value (y>0), the contribution is the standard Gaussian NLL:
+0.5 * ((y - mu) / sigma)^2 + log(sigma).
+
+Literature:
+    Zhang, J. et al. (2021). "Deep Tobit Networks." Neural Networks, 144.
+    DTN-I: ReLU output = Type-I Tobit. Outperforms standard DNNs on
+    censored microeconometric data.
+
+    Danăilă, V. & Buiu, C. (2024). "Deep Censored Regression."
+    Pattern Analysis and Applications. Reparametrized variant has
+    globally concave log-likelihood — no local optima.
+
+    Jacobson, T. & Zou, H. (2024). "Penalized Tobit." JBES, 42(1).
+    MSE advantage over OLS grows with censoring proportion q.
+    At our q~0.95, the advantage is massive.
+
+Research context: GitHub issue #36 (Path A in remediation roadmap).
+"""
+
+import logging
+import math
+
+import torch
+import torch.nn as nn
+
+logger = logging.getLogger(__name__)
+
+
+class TobitLoss(nn.Module):
+    """
+    Type-I Tobit censored-normal negative log-likelihood.
+
+    L(y, mu, sigma) = {
+        -log Phi(-mu/sigma)                    if y = 0  (censored)
+        0.5 * ((y - mu)/sigma)^2 + log(sigma)  if y > 0  (observed)
+    }
+
+    The input must be the PRE-ReLU latent (mu), not the post-ReLU output.
+    The target is in log1p-space (non-negative, with exact zeros for
+    censored observations).
+
+    Parameters
+    ----------
+    sigma : float
+        Fixed scale parameter. Controls the width of the latent normal.
+        sigma=1.0: standard normal latent (start here).
+        Smaller sigma: sharper censoring boundary, stronger gradient for
+        near-zero latent values.
+    """
+
+    needs_latent = True
+
+    def __init__(self, sigma: float = 1.0):
+        super().__init__()
+        if sigma <= 0:
+            raise ValueError(f"sigma must be > 0, got {sigma}")
+        self.sigma = sigma
+        logger.info(f"TobitLoss initialized: sigma={sigma}")
+
+    def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        """
+        Compute Tobit NLL.
+
+        Args:
+            input: Pre-ReLU latent mu (any shape). NOT post-ReLU.
+            target: Ground truth in log1p-space (same shape as input).
+                    Zeros are treated as censored observations.
+
+        Returns:
+            Scalar loss tensor.
+        """
+        z = input / self.sigma
+        censored = target == 0
+
+        loss = torch.zeros_like(input)
+
+        if censored.any():
+            loss[censored] = -torch.special.log_ndtr(-z[censored])
+
+        observed = ~censored
+        if observed.any():
+            residual = (target[observed] - input[observed]) / self.sigma
+            loss[observed] = 0.5 * residual**2 + math.log(self.sigma)
+
+        return loss.mean()

--- a/views_hydranet/utils/tobit_loss.py
+++ b/views_hydranet/utils/tobit_loss.py
@@ -73,6 +73,7 @@ class TobitLoss(nn.Module):
         if sigma <= 0:
             raise ValueError(f"sigma must be > 0, got {sigma}")
         self.sigma = sigma
+        self._log_sigma = math.log(sigma)
         logger.info(f"TobitLoss initialized: sigma={sigma}")
 
     def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
@@ -98,6 +99,6 @@ class TobitLoss(nn.Module):
         observed = ~censored
         if observed.any():
             residual = (target[observed] - input[observed]) / self.sigma
-            loss[observed] = 0.5 * residual**2 + math.log(self.sigma)
+            loss[observed] = 0.5 * residual**2 + self._log_sigma
 
         return loss.mean()

--- a/views_hydranet/utils/utils.py
+++ b/views_hydranet/utils/utils.py
@@ -14,6 +14,7 @@ from views_hydranet.utils.lognormal_nll_loss import LogNormalFixedSigmaLoss
 from views_hydranet.utils.mtloss import MultiTaskLoss
 from views_hydranet.utils.pareto_loss import ParetoLoss
 from views_hydranet.utils.shrinkage_loss import ShrinkageLoss
+from views_hydranet.utils.tobit_loss import TobitLoss
 from views_hydranet.utils.warmup_decay_lr_scheduler import WarmupDecayLearningRateScheduler
 
 logger = logging.getLogger(__name__)
@@ -74,6 +75,13 @@ LOSS_REG_REGISTRY: dict[str, Any] = {
         "params": ["loss_reg_pareto_alpha"],
         "factory": lambda config, device: ParetoLoss(
             alpha=config["loss_reg_pareto_alpha"],
+        ).to(device),
+    },
+    "tobit": {
+        "cls": TobitLoss,
+        "params": ["loss_reg_sigma"],
+        "factory": lambda config, device: TobitLoss(
+            sigma=config["loss_reg_sigma"],
         ).to(device),
     },
 }


### PR DESCRIPTION
## Summary

- **TobitLoss** (`views_hydranet/utils/tobit_loss.py`): Type-I Tobit censored-normal NLL. Censored cells (y=0) get `-log Φ(-μ/σ)` gradient pushing latent negative; observed cells (y>0) get standard Gaussian NLL. Dense gradient from ALL cells — replaces the gradient-starving hurdle mask.
- **ModelOutput.reg_latent**: Exposes pre-ReLU activations from decoder heads. All tuple-unpacking call sites converted to named access.
- **Training engine wiring**: `needs_latent` protocol routes pre-ReLU latent to Tobit loss while keeping post-ReLU for inference feedback. Hurdle mask automatically bypassed when latent loss is active.
- **Config validation**: `loss_reg='tobit'` + `hurdle_threshold` raises `ValueError` (contradictory). CIC updated.
- **S2 isolation result recorded**: Hurdle mask confirmed as root cause — 10⁹× metric divergence vs baseline.

## Evidence

S2 isolation test (hurdle_threshold=0.0 only):

| Target | S0 Baseline CRPS | S2 Hurdle CRPS | Ratio |
|--------|-----------------|----------------|-------|
| lr_sb | 0.291 | 2.2×10⁹ | 7.6×10⁹ |
| lr_ns | 0.104 | 19.6×10⁹ | 1.9×10¹¹ |
| lr_os | 0.255 | 802×10⁶ | 3.1×10⁹ |

Classification heads (not affected by hurdle): ~100× worse (shared encoder coupling), not diverged.

## Test plan

- [x] 27 new tests in `test_tobit_loss.py` (interface, censored, observed, mixed, numerical stability, registry, ModelOutput)
- [x] Existing 618 tests pass (0 regressions)
- [x] Ruff lint + format clean
- [x] CIC `HydraNetConfig.md` updated with new failure mode
- [ ] Run S2a-Tobit isolation config to validate convergence (next step after merge)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)