### PR TITLE
feat: log multi-task loss weights to wandb (issue #48)

### DIFF
--- a/views_hydranet/train/training_engine.py
+++ b/views_hydranet/train/training_engine.py
@@ -618,6 +618,18 @@ def training_loop(
                             }
                         )
 
+                # Issue #48: log multi-task loss weights once per lesson
+                import wandb
+
+                if wandb.run is not None:
+                    mtl_names = config.get("regression_targets", []) + config.get(
+                        "classification_targets", []
+                    )
+                    mtl_log_vars = multitaskloss_instance.log_vars.detach()
+                    wandb.log(
+                        {f"mtl_log_var/{n}": lv.item() for n, lv in zip(mtl_names, mtl_log_vars)}
+                    )
+
             # ADR-056: log scheduled sampling epsilon once per lesson (outside loss gate)
             if ss_mixer is not None:
                 import wandb


### PR DESCRIPTION
## Summary

- Logs `mtl_log_var/{target_name}` to wandb once per lesson after optimizer step
- Enables diagnosing whether the Kendall et al. (2018) multi-task balancer has converged
- Also closes #46 (matplotlib Agg fix — already shipped in PR #47)

## Context

Training loss curves show classification (focal) much more volatile than regression (Tobit), and total loss appears driven primarily by regression. Whether this is correct behavior or a convergence issue is impossible to diagnose without seeing the learned task weights.

## Test plan

- [x] 703 tests passing, 0 regressions
- [x] Logging uses same pattern as sigma and epsilon logging (lazy wandb import, `wandb.run is not None` guard)

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)