### PR TITLE
Retire freeze_h + rollout-training dossier (Axis B) — C-113

### DIFF
--- a/docs/ADRs/active/027_autoregressive_inference_strategy.md
+++ b/docs/ADRs/active/027_autoregressive_inference_strategy.md
@@ -4,7 +4,7 @@
 |---------------------|-------------------|
 | Subject             | The Forecasting Feedback Loop |
 | ADR Number          | 027               |
-| Status              | Accepted          |
+| Status              | Accepted (amended 2026-06-05: §2 `freeze_h` retired) |
 | Author              | Gemini CLI        |
 | Date                | 04.02.2026        |
 
@@ -19,11 +19,10 @@ We enforce a standardized execution pattern for multi-step inference, centered o
 *   **The Chain:** For $t > 0$, the model input $X_t$ is the prediction $\hat{y}_{t-1}$ from the previous step.
 *   **Dimensional Symmetry:** Predictions MUST be reshaped and normalized to match the input feature space (e.g., Log-Space) before being fed back as $X_t$.
 
-### 2. Hidden State Management (`hs` vs `hl`)
-To manage model "memory" during long horizons, we implement three explicit freezing strategies:
-1.  **None:** Standard update of both Short-term (`hs`) and Long-term (`hl`) memory.
-2.  **Freezing (`hs` or `hl`):** Selectively prevents the update of specific memory components. This is used to test the stability of spatial features (`hs`) vs. temporal momentum (`hl`).
-3.  **Random Freezing:** A stochastic stability test where hidden state channels are partially updated.
+### 2. Hidden State Management
+The rollout performs a **standard update of both short-term (`hs`) and long-term (`hl`) memory at every step** — the hidden state always evolves freely.
+
+> **Superseded 2026-06-05 — `freeze_h` retired.** This section originally defined three selective hidden-state *freezing* strategies (`none` / `hs`·`hl` / `random`). They were removed: the ablation showed freezing was inert against the C-113 runaway (the divergence rides the prediction→input feedback path, not the recurrent state) while creating a train/inference mismatch. Only the former `none` behaviour remains. See the Rationale update.
 
 ### 3. The Persistence Gate
 *   **Hidden State Initialization:** Hidden states must be initialized spatially based on the target grid resolution (ADR 025). 

--- a/docs/ADRs/active/027_autoregressive_inference_strategy.md
+++ b/docs/ADRs/active/027_autoregressive_inference_strategy.md
@@ -37,10 +37,21 @@ To manage model "memory" during long horizons, we implement three explicit freez
 
 ### Beige Team (Robustness)
 - Verify that if the model produces non-finite values (`NaN`, `Inf`), the autoregressive loop fails immediately (Panic Check).
-- Verify that `freeze_h` options outside the defined list (`hs`, `hl`, `none`, `random`) raise a `ValueError`.
+- ~~Verify that `freeze_h` options outside the defined list (`hs`, `hl`, `none`, `random`) raise a `ValueError`.~~ **Retired 2026-06-05** — `freeze_h` removed (see Rationale update); the rollout always evolves the full state. Guard: `tests/test_inference_logic.py::test_freeze_h_option_retired`.
 
 ### Red Team (Invincibility)
 - Verify that the hidden state `h` is never "shared" between independent stochastic samples, ensuring each sample path is mathematically isolated.
 
 ## Rationale
-This strategy ensures that HydraNet's forecasting behavior is consistent and auditable. By making the hidden state freezing explicit, we allow researchers to isolate whether model drift is caused by "forgetting" (hl) or "spatial confusion" (hs).
+This strategy ensures that HydraNet's forecasting behavior is consistent and auditable.
+
+> **Update 2026-06-05 — `freeze_h` retired.** The `freeze_h` mechanism (modes
+> `hs`/`hl`/`all`/`none`/`random`) was removed. The pre-registered `freeze_h` ablation
+> (`reports/results_freezeh_ablation.md`) showed every mode — including `all` — explodes
+> identically under the C-113 runaway, proving the divergence rides the prediction→input
+> *feedback* path, not the recurrent state; freezing was therefore **inert** against the
+> failure it was meant to study, while creating a train/inference mismatch (training
+> evolves the full state, inference froze part of it). The rollout now always evolves the
+> full ConvLSTM state (the former `"none"` mode). The durable fix for autoregressive
+> drift is **Axis-B rollout training** (`reports/2026-06-05_rollout_training_dossier/`,
+> ADR-058 candidate; register C-113/C-125/C-126).

--- a/docs/CICs/HydraNetConfig.md
+++ b/docs/CICs/HydraNetConfig.md
@@ -23,7 +23,7 @@ The `HydraNetConfig` is the **Schema** of the HydraNet pipeline. Its primary pur
 
 ## 3. Responsibilities and Guarantees
 
-- **Field Validation:** Guarantees that all 71 fields are type-checked and constraint-validated (e.g., `dropout_rate` in [0.0, 1.0], `input_channels >= 1`).
+- **Field Validation:** Guarantees that all 70 fields are type-checked and constraint-validated (e.g., `dropout_rate` in [0.0, 1.0], `input_channels >= 1`). *(`freeze_h` retired 2026-06-05 — see ADR-027 update.)*
 - **Feedback Clamp (C-113):** `feedback_clamp_log1p` is an optional per-target log1p ceiling (`list[float] | None`, default `None`) bounding only the autoregressive feedback input, never an emitted prediction. See `reports/preanalysis_feedback_clamp.md`.
 - **Balancer Freeze (C-113 bisect):** `freeze_multitask_balancer` (`bool`, default `False`) excludes the MultiTaskLoss `log_vars` from the optimizer (pre-C-111 equal-weighting regime). See `reports/preanalysis_balancer_bisect.md`.
 - **Checksum Laws (ADR-009):** Guarantees `input_channels == len(features)` and `time_steps == len(steps)`.

--- a/reports/2026-06-05_rollout_training_dossier/00_README.md
+++ b/reports/2026-06-05_rollout_training_dossier/00_README.md
@@ -1,0 +1,95 @@
+# Rollout-Training Dossier — Axis B ("train the model the way it is used")
+
+**Opened:** 2026-06-05 · **Status:** design under review · **Owner:** simon
+**Branch context:** `development` (C-113 autoregressive-runaway program)
+
+---
+
+## 1. Purpose
+
+`HydraBNUNet06_LSTM4` is trained one-step-ahead but **run 36 steps free-running** at
+inference. The prediction→input feedback loop — the exact operator the io-gain
+diagnostic identified as the runaway carrier (`scripts/diagnose_io_gain.py`,
+`reports/results_freezeh_ablation.md`) — receives **zero gradient** during training
+(`training_engine.py:200`, `prev_pred = t1_pred.detach()`). This dossier designs the
+fix at the level the literature says it must live — the **training algorithm**, not the
+architecture and not an inference-time hard-prior hack. We call it **Axis B**:
+*train against the rollout the model will actually perform.* Two graded
+implementations are on the table (pushforward, GTF) plus an adversarial maximal
+option (Professor Forcing), all governed by one config hyperparameter,
+`rollout_horizon` (K).
+
+## 2. Relationship to prior work / ADRs
+
+- **Complements / supersedes parts of:** ADR-056 (scheduled sampling — the existing,
+  *detached + Bernoulli-masked + biased* cousin of these methods); ADR-028 §2
+  (deterministic-recurrence stabilizers — clamps, the symptom-level fallback);
+  ADR-057 (variational/locked dropout — the *posterior* fix, orthogonal to the
+  *dynamics* fix designed here).
+- **Builds on the C-113 evidence base:** `reports/results_balancer_bisect.md`,
+  `reports/preanalysis_balancer_sweep.md` (the C-111 balancer is the *acute*
+  trigger; this dossier addresses the *chronic* train/inference mismatch that makes
+  the model fragile enough for the balancer to tip it over).
+- **Will graduate to:** a proposed ADR (`02_design` → ADR-058 candidate) once the
+  method review + a pre-registered experiment clear it.
+- **Distinct from:** the ZITD distributional-head dossier
+  (`reports/2026-06-05_distributional_head_dossier/`) — that fixes *what the head
+  emits* (chronic MCR); this fixes *how the recurrence is trained*. They compose.
+
+## 3. Document index
+
+| # | File | Role | Status |
+|---|------|------|--------|
+| 00 | `README` | spine (this file) | living |
+| 01 | `literature` | the three papers + recurrent-stability neighbours, annotated | drafted 2026-06-05 |
+| 02 | `design` | the Axis-B design + the `rollout_horizon` HP + GPU-cost analysis | drafted 2026-06-05 — **reviewed (see 02b); revisions pending** |
+| 02b | `method_review` | expert-method-review panel verdict + methodological risks | done 2026-06-05 |
+| 03 | `harness_and_invariants` | guardrails (to build) | TODO |
+| 04 | `roadmap` | gated implementation/experiment sequence | TODO |
+| 05 | `analysis_plan` | first pre-registered experiment | TODO (after review) |
+| 06 | `glossary` | exposure bias, pushforward, GTF, α, K, zero-stability… | TODO |
+| 07 | `experiment_log` | append-only ledger | TODO |
+
+## 4. Harness at a glance
+
+- **Already exists:** `scripts/diagnose_io_gain.py` (retrain-free free-running
+  attractor + operator-gain probe — the primary cheap readout); the GPU-enforced
+  sweep driver pattern (`views-models/scripts/run_balancer_sweep.sh`);
+  `ReproducibilityGate.lock_entropy`.
+- **To build (→ `03`):** a training-time rollout-stability invariant test (the
+  fed-back operator's gradient is non-zero and finite under the new path); a parity
+  guard that the *one-step* training path is byte-identical when `rollout_horizon=1`;
+  a per-step-loss monotonicity/curvature check across K.
+
+## 5. Current state & next actions
+
+- [x] Read the three papers in full (`01`).
+- [x] Pin the exact current behaviour: BPTT flows through `h`; the prediction
+      feedback is **detached**; SS is Bernoulli@`ss_epsilon` (`training_engine.py:178–200`).
+- [x] Draft `02_design`.
+- [x] **Run `expert-method-review` on `02_design`** (Hochreiter / DL-engineer /
+      Sutton / Gneiting / +Shi / +Operational) → `02b`. Verdict: **design sound, layer
+      right, B1→B2→B3 ordering right; NOT yet experiment-ready** until the readout
+      measures calibration (not just attractor magnitude), the proper-score quarantine
+      is operationalised, and the chaos-premise + `seq_len`-vs-36 checks are done.
+- [ ] **Fold the 6 review fixes into `02`** before pre-registration: gradient clipping
+      (Hochreiter); calibration/sharpness readout + annealed stability weight
+      (Gneiting); explicit feedback-space spec (Shi); measured K=12 memory + checkpoint
+      plan (DL-engineer); `seq_len`-vs-36 check + a direct-multi-horizon baseline number
+      (Sutton); promote the chaos-premise to a B2-blocker.
+- [ ] `register-risk` the 6 methodological risks (M-RT1…M-RT6 in `02b` §7).
+- [ ] Kill `freeze_h` (Element 1) — `freeze_h="none"`, remove the inference-time
+      state-freeze; **gate behind the `rollout_horizon=1` parity guard + golden_hour
+      re-eval** (Operational). Grounded in `reports/results_freezeh_ablation.md` (inert).
+- [ ] `03` harness + `05` pre-registered first experiment (B1 pushforward, K=1 default).
+- [ ] **Sequence the program after the C-111 balancer verdict closes** (don't tune
+      rollout HPs atop the unattributed acute trigger).
+- **Strongest live dissent (D5):** fixing the point runaway may not fix — and could
+  worsen (mean-hedging/blurring) — the chronic MCR/zero-rate calibration problem. Carry
+  as a falsifier, not a footnote.
+
+## 6. Conventions
+
+Numbered, dated docs; `00_README` living, the rest point-in-time. git-tracked via
+`git add -f` (reports/ is gitignored). On close, move to `reports/archived/`.
+Risks go to the register, not here.

--- a/reports/2026-06-05_rollout_training_dossier/01_literature.md
+++ b/reports/2026-06-05_rollout_training_dossier/01_literature.md
@@ -1,0 +1,148 @@
+# 01 — Literature (Axis B / rollout training)
+
+**Drafted:** 2026-06-05. Read in full this session: the three primary papers below.
+Grouped by role. Each entry: *what it is* → *what we take from it*. Gaps-to-fetch at
+the end.
+
+---
+
+## A. The three primary methods (read in full)
+
+### A1. Brandstetter, Worrall & Welling (2022) — *Message Passing Neural PDE Solvers* (ICLR). The **pushforward trick** + **temporal bundling**.
+`incoming/recurrent_stability/Brandstetter2022_MessagePassingPDE_pushforward.pdf`
+
+- **Names our problem exactly.** Autoregressive solvers map `uᵏ → uᵏ⁺¹`. One-step
+  training minimises `L₁ₛₜₑₚ = E[L(A(uᵏ), uᵏ⁺¹)]`. At test, *"small errors in A
+  accumulate over rollouts of length > 1 (the vast majority of rollouts), and lead
+  to divergence."* Interpreted as **overfitting to the one-step training
+  distribution** — the **distribution-shift problem**: after one step the solver
+  sees samples from `A_# pₖ` (the pushforward of the model's own output
+  distribution) ≠ `pₖ₊₁`, because *"errors always survive training."*
+- **The pushforward trick.** Add a stability loss
+  `L_stability = E[L(A(uᵏ + ε), uᵏ⁺¹)]` where `ε|uᵏ` is an **adversarial-style
+  perturbation chosen so `uᵏ + ε ~ A_# pₖ`** — achieved cheaply by setting
+  `uᵏ + ε = A(uᵏ⁻¹)`, i.e. **the model's own one-step-prior prediction**. Total loss
+  `= L₁ₛₜₑₚ + L_stability`.
+- **The cheap implementation (the part we take).** *"We implement this by unrolling
+  the solver for 2 steps but only backpropagating errors on the last unroll step…
+  We found it important not to backpropagate through the first unroll step. This is
+  not only faster, it also seems to be more stable."* (Fig. 2: one-step = grad 1
+  step; unrolled = grad through all N steps; **pushforward = grad through last step
+  only**.) ⇒ **flat activation memory in K**, ~K× forward cost.
+- **Adversarial-by-construction ≫ random noise.** Ablation (Fig. 5b): pushforward
+  beats Gaussian-noise injection (Sanchez-Gonzalez 2020); *"injecting Gaussian
+  perturbations appears worse than using none… they lead to lower accuracy, by
+  nature of injecting noise into the system."* → **a direct strike against any "just
+  add input noise" patch.**
+- **Temporal bundling.** Predict K steps per call (`u⁰ → u¹:ᴷ`) → fewer solver calls
+  → fewer distribution shifts → slower error propagation.
+- **Zero-stability link (Hairer).** `‖A(u⁰+ε) − u¹‖ < κ‖ε‖`; pushforward minimises κ
+  directly. Theoretical hook for "bounded amplification."
+- **TAKE:** the *cheapest* Axis-B implementation. We already **detach** the fed-back
+  prediction (`prev_pred.detach()`) — so the missing pieces are (i) compute & weight
+  the loss on the *prediction-from-fed-back-input* always (not Bernoulli@ε), (ii)
+  ensure K reaches the blow-up onset (~step 12). Memory-cheap; no deep BPTT graph.
+
+### A2. Hess, Monfared, Brenner & Durstewitz (2023) — *Generalized Teacher Forcing for Learning Chaotic Dynamics* (ICML). **GTF**.
+`incoming/deep_consored/hess23a.pdf`
+
+- **Exploding gradients are a *principle* problem, not an architecture problem.**
+  Via Mikhaeil et al. (2022): if the target system is chaotic (max Lyapunov exponent
+  `λ_max > 0`), the BPTT Jacobian product `∂z_t/∂z_r = ∏ Jₖ` (Eq. 5) **necessarily
+  explodes** as horizon T→∞. Architectures that bound it (LSTM, antisymmetric RNN,
+  Lipschitz RNN, unitary RNN) *"either limit expressiveness such that chaotic
+  dynamics cannot be learned, or still struggle with exploding gradients."* ⇒ fix at
+  the **training-algorithm** level.
+- **GTF mechanism.** Linearly interpolate RNN-generated and target states before
+  applying the map: `z̃_t = (1−α) z_t + α z̄_t`, `0 ≤ α ≤ 1`. This scales **every**
+  Jacobian: `J_t = (1−α) J̃_t` (Eq. 7), so the product becomes
+  `∂z_t/∂z_r = (1−α)^{t−r} ∏ J̃_{t−k}` (Eq. 8). `α=0` → vanilla BPTT (explodes);
+  `α=1` → no gradient flow; in between, α **directly controls the gradient-product
+  norm.**
+- **Provably bounded.** Choosing `α* = 1 − 1/σ̃_max` bounds the product from above
+  (Prop. 2). A cheap upper bound `⌈σ̃_max⌉ = ‖A‖ + ‖W₁‖‖W₂‖` (Eq. 18), or an adaptive
+  data-Jacobian estimate `aGTF` (Eq. 23). **Annealing** strategy: start at `α=1`
+  (strong forcing) and decay toward the bounded-from-below `α*`.
+- **Train-only.** α is used *only in training*; at test the model evolves
+  autonomously. Forcing interval τ ≈ predictability time.
+- **Result.** On real-world chaotic data (ECG 5-d, EEG 64-d): shPLRNN+GTF beats
+  LSTM-TBPTT, reservoir computing, N-ODE, SINDy on attractor geometry (`D_stsp`) and
+  power-spectrum (`D_H`) by **up to ~an order of magnitude**; sparse-TF (Mikhaeil)
+  is worse than GTF ⇒ the *soft* interpolation matters.
+- **TAKE:** the *principled* Axis-B implementation, and the cleanest reframing of our
+  ADR-056 scheduled sampling: **SS is a hard-Bernoulli, detached, biased special case
+  of GTF.** GTF says — *soft-mix* the fed-back signal `(1−α)·pred + α·GT`, **keep the
+  gradient flowing** through the feedback loop (the operator that is currently
+  severed), and **bound** it via α. Caveat to carry into review: GTF's *theory* is
+  for chaotic systems; whether conflict-count dynamics are chaotic (λ_max>0) is
+  unestablished — see the Sutton/Gneiting fault line in `02`.
+
+### A3. Lamb, Goyal, Zhang, Zhang, Courville & Bengio (2016) — *Professor Forcing* (NIPS).
+`incoming/rollout_training/1610.09038v1.pdf`
+
+- **The mechanism we already half-use, and its critique.** Teacher forcing feeds
+  ground-truth `yₜ` back during training; at test the model feeds its own samples →
+  *"small prediction errors compound… the RNN's conditioning context diverges from
+  sequences seen during training."*
+- **Scheduled sampling is a biased estimator.** Bengio et al. (2015) mixes GT and
+  self-generated inputs, but (Huszár 2015) *"scheduled sampling yields a biased
+  estimator, in that even as examples and capacity → ∞, the procedure may not
+  converge to the correct model."* ⇒ a recorded limitation of our current ADR-056.
+- **Professor Forcing.** Train a **discriminator** (bidirectional RNN) to tell apart
+  the *behaviour sequences* (hidden states + outputs) produced in teacher-forcing
+  mode vs free-running mode; train the generator to (a) minimise NLL and (b) **fool
+  the discriminator** — making free-running dynamics indistinguishable from
+  teacher-forced. Matches the **distribution of trajectories**, not just point error.
+- **Designed for "train short, generate long."** *"In some domains the sequences
+  available at training time are shorter than the sequences we want to generate at
+  test time. This is usually the case in long-term forecasting tasks (climate
+  modeling, econometrics)… Professor Forcing can be used to improve performance in
+  this setting. Note that scheduled sampling cannot be used for this task, because it
+  still uses the observed sequence as targets."* — **our exact situation** (train
+  window ≪ 36-step inference rollout).
+- **Costs/limits.** ~3× teacher-forcing training time (sampling phase + feeding
+  hidden-state distributions to D); adversarial-training instability (they only
+  backprop D→generator when D accuracy ∈ [75%, 99%]). **No benefit** on word-PTB or
+  on sequences < 100 steps ⇒ pays off only when long-horizon dependencies dominate.
+- **TAKE:** the *maximal* option, catalogued not recommended-first. The "train short
+  / generate long" passage is the strongest external statement of why our problem is
+  real and why SS specifically cannot solve it.
+
+---
+
+## B. Recurrent-stability neighbours (held; support the "architecture won't save you" claim)
+`incoming/recurrent_stability/`
+
+- **Mikhaeil, Monfared & Durstewitz (2022)** — *On the difficulty of learning
+  chaotic dynamics* (the proof Hess builds on; **gap — not held, fetch**).
+- **Pascanu, Mikolov & Bengio (2013)** — *On the difficulty of training RNNs*
+  (`Pascanu2013_*.pdf`): the original exploding/vanishing-gradient analysis +
+  gradient clipping. Baseline lens for the DL-engineer seat.
+- **Miller & Hardt (2019)** — *Stable Recurrent Models*
+  (`MillerHardt2019_*.pdf`): stable RNNs ≈ feed-forward; the expressiveness cost of
+  enforcing stability — the counter-pressure to "just make it contractive."
+- **Arjovsky, Shah & Bengio (2016)** unitary RNN; **Chang et al. (2019)**
+  antisymmetric RNN; **Erichson et al. (2021)** Lipschitz RNN; **Miyato et al.
+  (2018)** spectral normalisation — the *architectural* stability family Hess argues
+  is insufficient for chaotic targets. The Hochreiter seat will weigh these vs the
+  training-level fix.
+
+## C. Already in the repo / corpus
+
+- **Bengio et al. (2015)** scheduled sampling
+  (`incoming/deep_consored/NIPS-2015-scheduled-sampling-*.pdf`) — our ADR-056 basis.
+- **Gal & Ghahramani (2016)** variational RNN dropout — the *posterior* mask fix
+  (ADR-057), orthogonal; cited here only to keep the two tracks distinct.
+
+## D. Gaps to fetch
+
+1. **Mikhaeil, Monfared & Durstewitz (2022)** — the chaotic-DS ill-posedness proof
+   (load-bearing for whether GTF's premise applies to us).
+2. **Huszár (2015)** — *How (not) to train your generative model* (the
+   scheduled-sampling bias argument, cited by both A1's lineage and A3).
+3. **Sanchez-Gonzalez et al. (2020)** — learned simulators / noise injection (the
+   baseline pushforward beats; lets us state the noise-injection alternative fairly).
+4. **Oreshkin et al. (2019)** — *N-BEATS* (the direct-multi-horizon alternative the
+   `02` design explicitly chooses *against*; cite it to make that choice honest).
+5. *(optional)* **Vlachas et al. (2023)** — backprop-through-time for forecasting
+   chaotic systems / annealing protocols (Hess cites for the annealing precedent).

--- a/reports/2026-06-05_rollout_training_dossier/02_design.md
+++ b/reports/2026-06-05_rollout_training_dossier/02_design.md
@@ -1,0 +1,268 @@
+# 02 — Design: Axis B, "train the model the way it is used"
+
+**Drafted:** 2026-06-05 · **Revised:** 2026-06-05 (folded in the `02b` method-review
+findings — see the **[R1–R6] tags** below and §10) · **Status:** reviewed; revisions
+folded in; pre-analysis plan (`05`) next · **Graduates to:** ADR-058 candidate.
+
+---
+
+## 1. The problem in one sentence
+
+`HydraBNUNet06_LSTM4` is optimised on a one-step-ahead objective but executed as a
+**36-step free-running autoregression** at inference; the prediction→input feedback
+operator that carries the runaway gets **no gradient** during training, so the model
+is never asked to be stable along the trajectory it will actually walk.
+
+## 2. What the code does today (grounded, not assumed)
+
+`views_hydranet/train/training_engine._process_sequence` (lines 178–231):
+
+```python
+prev_pred = None
+for i in range(seq_len - 1):                       # window steps
+    t0_gt = t0[:, idx.feat, :, :]
+    if ss_epsilon > 0.0 and prev_pred is not None: # ADR-056 scheduled sampling
+        mask = torch.rand(...) < ss_epsilon         #   hard Bernoulli @ ss_epsilon
+        t0_input = torch.where(mask, prev_pred, t0_gt)
+    else:
+        t0_input = t0_gt
+    output = model(t0_input, h)                     # h carried across steps
+    t1_pred, t1_pred_class, h = output.reg, output.cls, output.h_next
+    prev_pred = t1_pred.detach()                    # <-- feedback gradient SEVERED
+    ...                                             # per-step loss summed
+```
+
+Two facts that sharpen every design choice below:
+
+1. **The recurrent state `h` is *not* detached** → gradient already flows through the
+   ConvLSTM across the window (standard BPTT). So we are *not* fully teacher-forced in
+   the hidden-state sense.
+2. **The prediction feedback *is* detached** (`prev_pred = t1_pred.detach()`) and only
+   engaged with probability `ss_epsilon`. The io-gain diagnostic
+   (`scripts/diagnose_io_gain.py`; `reports/results_freezeh_ablation.md`) found the
+   runaway **rides this feedback loop** (operator gain ‖d reg/d x‖₂ > 1 at the visited
+   operating points), *not* the recurrent state. So the one operator empirically
+   responsible for the blow-up is the one operator that receives **zero training
+   signal** about its own multi-step behaviour.
+
+This is the "train/inference lie," stated precisely. It is *not* "no gradient
+anywhere through time" — it is "no gradient through the specific feedback path that
+diverges."
+
+## 3. Why this is the right layer to fix (and freeze_h is not)
+
+All three papers converge on the same claim from different fields:
+
+- **Hess/Mikhaeil:** for chaotic targets the gradient blow-up is a *principle*
+  problem — *architectural* constraints (LSTM, Lipschitz/antisymmetric/unitary RNN,
+  spectral norm) either can't fix it or kill expressiveness. Fix the **training
+  algorithm**.
+- **Brandstetter:** instability is *overfitting to the one-step distribution* — fix
+  the **training objective** (add the stability term).
+- **Lamb:** the conditioning context diverges — fix the **training objective**
+  (match free-running to teacher-forced dynamics).
+
+**Corollary — Element 1, kill `freeze_h`.** Freezing the LSTM cell/hidden state at
+inference (`execute_freeze_h_option` in `hydranet_inference.py`) is an
+inference-time *hard prior* that fights a symptom on the wrong operator (the state,
+which the diagnostic exonerated) and contradicts the literature's "fix it in
+training" consensus. The freeze_h ablation (`reports/results_freezeh_ablation.md`)
+already showed it is **inert** for the runaway. Decision: set `freeze_h="none"`,
+remove the inference-time state-freeze. This dossier supplies the real fix that lets
+us retire the hack rather than lean on it.
+
+## 4. The design space
+
+Two orthogonal axes. We are choosing on the **training** axis and explicitly *keeping*
+the recurrence.
+
+### 4.1 Recursive vs direct-multi-horizon (the axis we are *not* taking)
+Brandstetter's framing: **neural-operator/direct** methods map `initial → u(t)` in one
+shot (no recursion; N-BEATS, Oreshkin 2019 is the forecasting archetype) vs
+**autoregressive** methods iterate `A(Δt, u(t))`. Dropping recursion would sidestep
+the feedback loop entirely — but it discards the Markov/temporal inductive bias that
+matches conflict dynamics (this period's state conditions next period's), forces a
+fixed output horizon, and throws away the ConvLSTM we have. **We keep the recurrence
+and fix its training.** (N-BEATS is catalogued as the honest alternative; not chosen.)
+
+### 4.2 The three training-axis implementations (graded by cost/ambition)
+
+| | **B1 — Pushforward** (Brandstetter) | **B2 — GTF** (Hess) | **B3 — Professor Forcing** (Lamb) |
+|---|---|---|---|
+| **Idea** | add `L_stability` on the prediction made *from the model's own one-step-prior prediction* | soft-mix the fed-back signal `(1−α)·pred + α·GT`, keep gradient, **bound** via α | adversarial discriminator forces free-running dynamics ≈ teacher-forced |
+| **Feedback gradient** | **detached** across steps; grad only through the *last* step | **flows** through the rollout, scaled by `(1−α)^{t−r}` (provably bounded) | flows through the free-running rollout (to fool D) |
+| **Relation to our code** | we already detach; add the always-on stability term + reach K | the principled upgrade of ADR-056: SS = hard-Bernoulli, detached, *biased* GTF | a new discriminator network + adversarial loop |
+| **Activation memory** | **O(1) in K** (no deep graph) | **O(K)** (true BPTT through K) | O(K) + discriminator |
+| **Compute / step** | ~K forward + K one-step backprops | K forward + 1 BPTT-through-K | sampling pass + D forward/back; ~3× TF |
+| **Bias** | unbiased on the stability term | α-bounded; annealed to remove bias | matches trajectory distribution (strongest) |
+| **New machinery** | minimal (loss term + horizon loop) | α schedule + (optional) σ̃_max bound | discriminator arch + adversarial scheduling |
+| **Risk** | may under-train very-deep-horizon stability (grad only 1 step) | BPTT memory; α mis-set → kills learning or still explodes | adversarial instability; 3× cost; may not help < 100 steps |
+
+**Reading.** B1 is the cheapest and closest to the current code (we already do the
+hard part — detaching). B2 is the most *on-target*: the diagnostic says the runaway is
+the feedback loop, and GTF is precisely "put **bounded** gradient back into the forced
+feedback." B3 is the maximal, distribution-matching option — kept in the catalogue,
+not proposed first (cost + the "no benefit < 100 steps" caveat, and our window may be
+short).
+
+## 5. The `rollout_horizon` hyperparameter (K)
+
+A single config knob, the "look-ahead depth" the user described (n-beats-like):
+
+- `rollout_horizon: int = 1` → **byte-identical to today's one-step path** (parity
+  guard in `03`). The feature is *off* by default until validated.
+- `K ∈ {5, 10, 12, 36}` → unroll/penalise K autoregressive steps. **Candidate default
+  K=12**, chosen to reach the empirically observed blow-up onset (~step 12 in the
+  step-wise eval), not the full 36 — bounded GPU cost, covers the regime that breaks.
+- **[R5] Check `seq_len` vs 36 *first* (Sutton's cheap lever).** If the training
+  window is shorter than the 36-step inference rollout, the most general, least-clever
+  "rollout training" is simply to **train on 36-step windows** — verify the current
+  `seq_len` before implementing any loss term; it may dominate the fancy options.
+- K interacts with the implementation:
+  - **B1:** K = number of pushforward unroll steps (memory flat in K).
+  - **B2:** K = the BPTT truncation window (memory linear in K → the cost driver).
+  - **Temporal bundling (Brandstetter):** an optional second knob — emit a bundle of
+    `b` steps per call so K rollout-steps cost `K/b` model calls. Deferred; logged.
+- **[R2] The readout always runs the full 36 steps even when K<36** — see §8; a
+  K-step training horizon must be *certified* against the full inference horizon.
+- **α (B2 only):** train-only; annealed `1 → α* = 1 − 1/σ̃_max`. For a ConvLSTM, the
+  exact σ̃_max is intractable; use the annealing heuristic (start strongly forced,
+  decay) and monitor the per-step-loss curvature rather than computing the bound.
+
+## 6. GPU-cost analysis
+
+The crux of the user's concern. Per training example, window length `L`, horizon `K`:
+
+| Strategy | Fwd passes | Backward | Activation memory | Notes |
+|---|---|---|---|---|
+| One-step (today) | L | 1-step (through `h`) | O(L) for `h` graph | baseline |
+| **B1 pushforward** | L·(1 + 1) | K × one-step | **O(1) in K** | ~2× forward; **no extra graph** — this is why Brandstetter "don't backprop the first step" matters |
+| **B2 GTF / TBPTT** | L | BPTT through K | **O(K)** feature maps | the expensive one; the ConvLSTM U-Net stores `[B,C,H,W]` per step × K |
+
+**[R4] Concrete envelope — measure, don't assume.** The model runs at `window_dim=32`
+(`diagnose_io_gain --hw 32`). A ConvLSTM U-Net stores `[B, C, H, W]` feature maps *per
+step per skip-level*, so the K=12 BPTT footprint must be **measured** at the real batch
+size before committing to B2 — the earlier "very likely feasible" was a hand-wave the
+review (DL-engineer) rejected. **Plan if it OOMs:** `torch.utils.checkpoint` on the
+per-step U-Net forward (recompute activations in the backward pass; ~30% compute for
+O(√K) memory). Report the measured peak before any full retrain.
+
+**Mitigations (in order of preference):**
+1. **Pick B1 first** — flat memory in K sidesteps the problem entirely; only ~2×
+   forward cost. Validate whether one-step-back stability training is *enough* before
+   paying for BPTT.
+2. **Truncated BPTT** — K=12 not 36 (TBPTT is exactly what the LSTM-TBPTT baselines in
+   Hess Table 1 use).
+3. **Gradient checkpointing** (`torch.utils.checkpoint`) on the per-step U-Net forward
+   → recompute activations in the backward pass; trades ~1.3–2× compute for ~O(√K) or
+   O(1) memory. The standard lever if K must be large.
+4. **Temporal bundling** — fewer model calls per K rollout-steps.
+5. **GTF's α-bounding is itself a stability mitigation** — it prevents the
+   gradient-magnitude blow-up that would otherwise make deep-K BPTT diverge (the
+   reason naive unrolled training "is hard to train," per Brandstetter §2.3).
+
+**Honest cost statement:** B1 ≈ 2× current train time, no memory risk. B2 ≈
+(1 + checkpoint_overhead)× compute and O(K) (or O(√K) checkpointed) memory — the only
+option with a real OOM risk, mitigated by K and checkpointing.
+
+## 7. Proposed path (updated 2026-06-05 per the `02b` method review)
+
+0. **[R6] Sequence the whole program *after* the C-111 balancer verdict closes**
+   (Operational seat) — don't tune rollout HPs atop the still-unattributed acute
+   trigger. *(The in-flight sweep already shows freezing is seed-fragile —
+   `seed4_frozen → inf` — which strengthens the case that exposure bias, not the
+   balancer, is the root.)*
+1. **Element 1:** kill `freeze_h` — **gated** behind the `rollout_horizon=1` parity
+   guard **+ a golden_hour re-eval** (Operational), not flipped globally blind. Backed
+   by the inert-freeze_h ablation. (Plan: see the freeze_h-kill plan, separate doc.)
+2. **[R5] Verify `seq_len` vs 36** before writing any loss term — lengthening the
+   training window may be the cheapest rollout training of all.
+3. **Implement B1 (pushforward) behind `rollout_horizon`,** `K=1` parity-default —
+   smallest diff to the current detached-feedback code, no memory risk, beats noise
+   injection (Brandstetter). With the review's guardrails:
+   - **[R2] readout certifies the full 36-step horizon** (in-range attractor + step-wise
+     CRPS through *all* 36 steps), not just steps ≤K;
+   - **[R1+R3] calibration & sharpness in the readout** — PIT/coverage + MCR/zero-rate,
+     **not** attractor magnitude alone (the runaway is a *point* pathology; MCR is a
+     *calibration* one — fixing one need not fix the other, and mean-hedging could
+     worsen it);
+   - **[R1] proper-score quarantine:** the `L_stability` weight is **annealed / kept
+     small**; **CRPS is reported uncontaminated** as the headline (stability terms are
+     regularisers, not proper scores);
+   - **a cheap dose-response** (K∈{1,5,12} × stability-weight on the `diagnose_io_gain`
+     proxy) *before* a full golden_hour retrain.
+4. **If B1 under-delivers on deep-horizon stability,** escalate to **B2 (GTF)** —
+   un-detach, soft-mix `(1−α)·pred + α·GT`, anneal α, TBPTT at K with checkpointing.
+   With: **[R7] gradient clipping** (Pascanu/Hochreiter — standard companion to any
+   BPTT); **α treated as heuristic gradient control, not chaos theory** ([R3], see §9
+   Q1); **[R3-space] interpolation in the model's input space** (the gain was measured
+   in log1p space — get the space wrong and α is meaningless); **[R4] measured K=12
+   memory + checkpoint**. GTF also cleanly **subsumes and de-biases ADR-056 scheduled
+   sampling** (soft α-mix replaces the hard Bernoulli mask).
+5. **B3 (Professor Forcing)** stays catalogued; revisit only if both B1 and B2 fix
+   *point* stability while the *trajectory distribution* (calibration) stays wrong.
+
+## 8. Invariants this must respect (full set → `03`)
+
+- **Parity:** `rollout_horizon=1` ⇒ training path byte-identical to today.
+- **[R1] Proper score stays the headline:** the per-step predictive loss remains a
+  proper scoring rule (CRPS); pushforward/GTF stability terms are **regularisers**,
+  **annealed / small-weighted**, never a replacement for the score; CRPS is reported
+  uncontaminated (the Gneiting constraint — see fault line).
+- **[R1] Calibration is a first-class readout:** every rollout-training experiment
+  reports PIT/coverage + MCR + zero-rate alongside the point/attractor metric.
+  "C-113 solved" may **not** be declared on attractor magnitude alone.
+- **No output capping:** stability comes from training dynamics, not magnitude clamps
+  (ADR-028 §2 clamps stay a separate, last-resort fallback).
+- **Feedback-gradient liveness:** a test asserting the fed-back operator's gradient is
+  non-zero and finite under B1/B2 (the thing that is currently zero).
+- **[R3-space] Feedback-space is explicit:** the fed-back quantity, the pushforward
+  perturbation, and any GTF interpolation all live in the **same space the model
+  consumes** (log1p space — where the io-gain `‖J‖₂>1` was measured), specified in the
+  pre-analysis plan.
+- **[R7] Gradient clipping** accompanies any path that backprops through the rollout
+  (B2): standard BPTT hygiene (Pascanu 2013).
+- **Train-only forcing:** α / pushforward affect training only; inference is unchanged
+  free-running (so the io-gain diagnostic remains a valid before/after probe).
+
+## 9. Open questions (seeded for the panel)
+
+1. **[R3 — promoted to a B2 BLOCKER] Is conflict-count dynamics actually chaotic
+   (`λ_max>0`)?** GTF's *theory* (the `α*=1−1/σ̃_max` bound) is only valid for chaotic
+   systems. If our explosion is the milder Brandstetter distribution-shift problem (not
+   Lyapunov divergence), B1 may suffice and B2's machinery is over-imported. **Must be
+   resolved before adopting B2** — and even then α is used as heuristic gradient
+   control, not as a correctness guarantee. *(Sutton / Gneiting; fetch Mikhaeil 2022.)*
+2. **Does training-the-rollout fix point stability but *not* calibration?** The
+   posterior-spread question is ADR-057's; if B1/B2 narrow the rollout but leave MCR
+   wrong, that argues for B3 or the distributional head. *(Gneiting.)*
+3. **K=12 vs 36:** does covering only the blow-up onset generalise to the full 36-step
+   horizon, or does a new instability appear past K? *(Hochreiter / DL-engineer.)*
+4. **Interaction with the C-111 balancer:** does rollout training make the active
+   (learnable) balancer safe again — i.e. is exposure-bias the *root* and the balancer
+   merely the *trigger*? *(ties to the balancer sweep — the in-flight sweep's
+   `seed4_frozen → inf` already hints "yes, exposure bias is the root.")*
+
+---
+
+## 10. Review-driven revisions (folded in 2026-06-05 from `02b`)
+
+The method-review verdict was *"design sound, layer right, ordering right — but not yet
+experiment-ready."* These binding changes (tagged `[R…]` above) close that gap:
+
+| Tag | Fix | From whom | Where |
+|-----|-----|-----------|-------|
+| **R1** | Calibration/sharpness (PIT, MCR, zero-rate) is a first-class readout; `L_stability` weight annealed/small; CRPS reported uncontaminated | Gneiting | §7.3, §8 |
+| **R2** | Readout certifies the **full 36-step** horizon even when K<36 | Hochreiter | §5, §7.3 |
+| **R3** | Chaos premise promoted to a **B2 blocker**; α = heuristic gradient control, not theory; interpolate in the model's input space | Sutton, Gneiting, Shi | §4.2, §7.4, §9-Q1 |
+| **R4** | K=12 memory **measured, not assumed**; checkpointing as the explicit plan | DL-engineer | §6 |
+| **R5** | Check `seq_len` vs 36 first — lengthening the window may be the cheapest fix | Sutton | §5, §7.2 |
+| **R6** | Sequence the program **after** the C-111 balancer verdict closes | Operational | §7.0 |
+| **R7** | Gradient clipping accompanies any rollout-BPTT path (B2) | Hochreiter | §8 |
+
+**Strongest live dissent carried forward (D5):** fixing the *point* runaway may not fix
+— and mean-hedging/blurring could worsen — the *chronic* MCR/calibration problem
+(ADR-057). This is a falsifier in the pre-analysis plan (`05`), not a footnote.
+
+The six methodological risks (M-RT1…M-RT6) are filed via `register-risk` (see the
+technical risk register).

--- a/reports/2026-06-05_rollout_training_dossier/02b_method_review.md
+++ b/reports/2026-06-05_rollout_training_dossier/02b_method_review.md
@@ -1,0 +1,315 @@
+# 02b — Expert Method Review of `02_design` (Axis B / rollout training)
+
+**Date:** 2026-06-05 · **Skill:** `expert-method-review` · **Target:** `02_design.md`
+**Gate:** this review **precedes** any training-loop change (per `00_README` §5).
+**Chair:** simon (not seated).
+
+---
+
+## 1. Target & decisions under review
+
+The Axis-B design fixes C-113 (autoregressive runaway in `HydraBNUNet06_LSTM4`, a
+ConvLSTM U-Net) at the **training-algorithm** level. Decisions:
+
+1. **Keep the recurrence; fix the training** (vs N-BEATS-style direct multi-horizon).
+2. **Put gradient back into the prediction→input feedback loop** that is currently
+   detached (`training_engine.py:200`) — the operator the io-gain diagnostic blamed.
+3. **Choose among** B1 pushforward (Brandstetter), B2 GTF (Hess), B3 Professor
+   Forcing (Lamb).
+4. **`rollout_horizon` K** config HP (proposed default K=12) + GPU cost (B1 flat
+   memory vs B2 O(K) BPTT; checkpointing; temporal bundling).
+5. **Kill `freeze_h`** (inference-time state-freeze hack).
+
+**DGP the design must respect.** Monthly PRIO-GRID conflict-count fields:
+spatiotemporal, **heavy-tailed/zero-inflated**, strongly **persistent**, with
+escalation bursts. *Crucially unestablished:* whether this DGP is **chaotic**
+(`λ_max > 0`) — the premise GTF's theory rests on. The observed explosion is an
+`expm1` out-of-range amplification of a log-space drift, which may be a *distribution-
+shift* artifact (Brandstetter) rather than *Lyapunov divergence* (Hess).
+
+## 2. Panel
+
+Chair-requested core + two adds to complete the fault lines (6 seats, within 4–7):
+
+| Seat | Why seated | Fault lines |
+|---|---|---|
+| **Sepp Hochreiter** | authored the LSTM; owns BPTT exploding/vanishing dynamics — the runaway's lineage | BPTT cost/stability; is-it-chaotic; B1-vs-B2 |
+| **DL-engineer archetype** | BPTT memory/throughput, optimization stability, HP surface | B1-vs-B2; cost |
+| **Rich Sutton** | bitter lesson; anti-hand-engineered-prior contrarian | is-it-chaotic; keep-vs-drop recurrence; over-engineering |
+| **Tilmann Gneiting** | proper scoring; sharpness s.t. calibration; CRPS purist | proper-score-vs-regularizer; point-stability≠calibration |
+| **Xingjian Shi** *(add)* | **authored ConvLSTM for spatiotemporal nowcasting** — our exact backbone and nearly our exact problem (multi-step rollout) | keep-vs-drop recurrence; blurring/calibration |
+| **Operational archetype** *(add)* | production GPU budget, freeze_h-removal blast radius, HP/reproducibility surface | feasibility; sequencing vs the open C-111 sweep |
+
+Adds justified: without **Shi** the "keep recurrence" claim has no authoritative
+anchor opposing Sutton's "drop it"; without the **operational** seat the GPU-cost and
+freeze_h-removal decisions have no production-reality check.
+
+## 3. Library grounding
+
+**Held & load-bearing (cited below):**
+- `recurrent_stability/Brandstetter2022_*` (B1), `deep_consored/hess23a.pdf` (B2),
+  `rollout_training/1610.09038v1.pdf` (B3) — all read in full this session (`01`).
+- `recurrent_stability/Pascanu2013_DifficultyTrainingRNNs.pdf` — exploding-gradient +
+  clipping (Hochreiter, DL-engineer).
+- `recurrent_stability/MillerHardt2019_StableRecurrentModels.pdf` — stability costs
+  expressiveness (the counter-pressure to "just make it contractive").
+- `recurrent_stability/{Erichson2021_LipschitzRNN, Chang2019_AntisymmetricRNN,
+  Arjovsky2016_UnitaryRNN, Miyato2018_SpectralNormalization}.pdf` — the architectural
+  stability family (Hochreiter's belt-and-suspenders; Hess's "insufficient alone").
+- `papers/Oreshkin2019_NBEATS.pdf` — **held** — the direct-multi-horizon alternative
+  (Sutton's baseline; Gneiting's "it's a point forecaster" objection).
+- `papers/Gneiting2007_StrictlyProperScoringRules.pdf`,
+  `papers/Gneiting2014_ProbabilisticForecasting.pdf`,
+  `papers/Gneiting2011_ComparingDensityForecasts.pdf`,
+  `papers/Dawid2007_GeometryProperScoringRules.pdf` — **held** — the proper-scoring /
+  energy-score grounding for Gneiting's seat.
+- `deep_consored/NIPS-2015-scheduled-sampling-*.pdf` — ADR-056's basis (the biased
+  estimator).
+
+**Gaps to fetch:**
+1. **Mikhaeil, Monfared & Durstewitz (2022)** — the chaotic-DS ill-posedness proof
+   GTF rests on. *Load-bearing for D1 (is-it-chaotic).*
+2. **Huszár (2015)** — the scheduled-sampling bias argument.
+3. **Sanchez-Gonzalez et al. (2020)** — learned simulators / noise injection (the
+   baseline pushforward beats; needed to state the noise alternative fairly).
+4. *(have, but cite)* **Gneiting & Raftery (2007)** energy score for multivariate /
+   trajectory forecasts — already covered by the held Gneiting set.
+
+## 4. Independent critiques
+
+### 4.1 Sepp Hochreiter — *the gradient-flow realist*
+- **Endorse the layer, with a warning that B2 reopens the original wound.** Fixing
+  this in training (not architecture) is right — but B2/GTF runs **BPTT through K
+  steps**, which is precisely the exploding/vanishing-gradient regime the LSTM was
+  invented to survive (Hochreiter & Schmidhuber 1997; Pascanu 2013). GTF's `(1−α)`
+  Jacobian-scaling (Hess Eq. 7–8) is *recognisably* a gradient-magnitude control —
+  kin to the constant-error-carousel intuition — so it is the right tool, but it must
+  be paired with **gradient clipping** (Pascanu) as standard hygiene; the design omits
+  clipping.
+- **Why is the LSTM gating not already protecting us?** The cell-state gating bounds
+  the *recurrent* path — but the runaway rides the **output→input feedback** path
+  (the diagnostic), which the gating does **not** guard. This is the real diagnosis:
+  we have a stable cell but an unguarded prediction-feedback operator with gain > 1.
+  The design should *say* this — it reframes B1/B2 as "train the one path the
+  architecture doesn't protect."
+- **Challenge K=12 truncation.** Truncated BPTT gives **biased gradients** for
+  dependencies longer than K (the long-term-dependency problem I spent a career on).
+  If the runaway compounds over 24–36 steps, training to 12 may certify the wrong
+  horizon. Either K=36 (with checkpointing) or a pre-registered falsifier that checks
+  steps 13–36.
+- **What to build alongside:** consider a **bounded-Lipschitz** complement
+  (Erichson 2021; Miyato 2018 spectral norm on the feedback operator). Hess says
+  architecture alone is insufficient *for chaotic systems* — but combined with
+  rollout training it is belt-and-suspenders, and it directly attacks the measured
+  `‖J‖₂ > 1`.
+
+### 4.2 DL-engineer archetype — *the throughput/memory pragmatist*
+- **B1-first ordering is correct and under-sold.** We already detach
+  (`prev_pred.detach()`), so B1 is a *small* diff: feed the model's own prediction
+  always (not Bernoulli@`ss_epsilon`), add the weighted stability term, loop to K.
+  ~2× forward, **flat activation memory** — essentially no OOM risk. Prototype it in
+  an afternoon; measure before paying for anything bigger.
+- **"Very likely feasible at K=12" (§6) is hand-waved — measure it.** A ConvLSTM
+  U-Net stores `[B, C, H, W]` feature maps *per step per skip-level*. Report the real
+  peak memory at K=12, current batch, 32×32 *before* committing to B2. If it OOMs,
+  `torch.utils.checkpoint` on the per-step forward trades ~30% compute for O(√K)
+  memory — standard, mention it as the plan not a footnote.
+- **The new HPs are a hidden cost.** B1 adds a stability-loss **weight**; B2 adds **α**
+  and its schedule. Tuning these on top of the *already-unstable* C-111 balancer is
+  two-unstable-knobs-at-once. Demand a **cheap dose-response** (sweep K∈{1,5,12} ×
+  weight on the `diagnose_io_gain` proxy, retrain-free where possible) before any full
+  golden_hour retrain.
+- **Bias of truncation is also a feature:** TBPTT at K=12 is exactly what the
+  LSTM-TBPTT baselines do (Hess Table 1) — defensible, just declare it.
+
+### 4.3 Rich Sutton — *the bitter-lesson contrarian*
+- **Kill `freeze_h` hardest — it is the anti-pattern.** A hand-coded inference-time
+  prior that freezes state is exactly the kind of human-engineered cleverness the
+  bitter lesson says loses. Unanimous, but I want it on record as *principle*, not
+  just "the ablation says it's inert."
+- **B1 is the *general* fix; be suspicious of B2/B3's added machinery.** "Train the
+  model the way you use it" is a general method (match train to test) — that scales.
+  GTF's α-bounding and Professor Forcing's discriminator are *added structure*. Reach
+  for them only if the general method demonstrably fails.
+- **Is the system even chaotic?** The design imports Hess's chaotic-DS apparatus
+  (Lyapunov exponents, `α* = 1−1/σ̃_max`) for a conflict-count forecaster that is
+  very likely **not** chaotic — it's persistent + heavy-tailed. The explosion looks
+  like `expm1`-out-of-range drift, not exponential trajectory divergence. **Don't
+  import a theory whose premise you haven't checked** (→ fetch Mikhaeil 2022; the
+  design's own §9-Q1 admits this — promote it from "open question" to "blocking check
+  before B2").
+- **The cheapest rollout training is a longer training window.** If the training
+  window is currently *shorter* than the 36-step inference rollout, the most general,
+  least-clever fix is to **train on 36-step windows** (more data/compute through the
+  rollout), not a bespoke loss term. Verify `seq_len` vs 36 first — it may dominate
+  the fancy options.
+
+### 4.4 Tilmann Gneiting — *the proper-scoring purist*
+- **The stability term is not a proper scoring rule — quarantine it.** Pushforward
+  `L_stability` and GTF's interpolation are **regularisers**, not proper scores
+  (Gneiting & Raftery 2007). If they are weighted into the objective with a fixed
+  nonzero coefficient, the minimiser is **no longer the true predictive
+  distribution** — you buy stability by biasing the forecast. Keep the coefficient
+  **small and/or annealed→0**, and **report CRPS uncontaminated** as the headline.
+  The design's §8 *states* this principle but the §7 path doesn't operationalise the
+  annealing — make it concrete.
+- **Point-stability ≠ calibration — your success metric is wrong.** `diagnose_io_gain`
+  measures whether the *point* trajectory stays in-range. The runaway is a *mean*
+  pathology; the chronic problem (MCR, ADR-057) is a *calibration* pathology. You can
+  fix the former and leave — or worsen — the latter. **The readout must include PIT /
+  coverage and sharpness**, not attractor magnitude alone. Declaring C-113 "solved"
+  on in-range-attractor would be a category error.
+- **Multi-step scoring: per-step CRPS misses path dependence.** Summed per-step CRPS
+  is proper *marginally* but ignores the joint distribution over the 36-step path. If
+  the trajectory shape matters (it does for escalation), the proper object is the
+  **energy score / variogram score** (Gneiting 2008/2011, held). At minimum, decide
+  explicitly whether you're scoring marginals or the path.
+- **On dropping recurrence for N-BEATS (held):** N-BEATS is a **point** forecaster
+  with no native predictive distribution. Switching to it would *regress* the
+  probabilistic objective we evaluate on. A reason to **keep** recurrence + a proper
+  distributional head — agrees with Shi, against Sutton's "drop it."
+
+### 4.5 Xingjian Shi — *the ConvLSTM nowcasting author*
+- **Rollout training is native to this backbone — endorse, this is solved territory.**
+  ConvLSTM nowcasting (Shi 2015; encoder-forecaster, Shi 2017) *already* unrolls the
+  forecaster over many steps and trains through it. "Keep the recurrence and train the
+  rollout" is the standard nowcasting recipe; the design is rediscovering a known-good
+  pattern, which is reassuring. The spatial+temporal inductive bias is exactly why
+  ConvLSTM fits — conflict has both. **Against Sutton's "drop it."**
+- **Beware the blurring failure mode — it couples to Gneiting's point.** Multi-step
+  ConvLSTM rollouts are notorious for **regression-to-the-mean blurring**: optimising
+  multi-step error rewards hedging toward the spatial mean. For zero-inflated conflict
+  fields this would *deflate* the predicted intensities and *worsen* the zero-rate/MCR
+  problem. **Monitor sharpness and the zero-rate**, not just stability. This is the
+  one place rollout training could actively hurt the chronic problem.
+- **The feedback is a *field*, not a scalar — what exactly is fed back matters.**
+  Specify whether the fed-back quantity is the post-`expm1` count field, the log-space
+  field, or the latent — the operator gain the diagnostic measured is in log1p space.
+  GTF interpolation `(1−α)·pred + α·GT` must happen in the **same space** the model
+  consumes; get this wrong and α means nothing.
+
+### 4.6 Operational archetype — *the production realist*
+- **Sequence this AFTER the C-111 balancer question closes.** The balancer×seed sweep
+  is in flight and F2 has already fired (seed-4-frozen → inf). Enabling rollout
+  training now adds knobs to a system whose acute instability is still unattributed —
+  you won't be able to tell which fix did what. Finish the balancer verdict first.
+- **`freeze_h` removal has blast radius.** It's a live config option across
+  golden_hour inference. Removing it changes the inference path for **every** model —
+  gate it behind the **parity guard** (`rollout_horizon=1` byte-identical) *and* a
+  re-eval of every golden_hour model with `freeze_h="none"` before merge. Don't flip
+  it globally blind.
+- **`rollout_horizon` as a per-model config HP fits the pattern** (views-models
+  configs) — but it's another reproducibility surface (manifest audit, C-43) and
+  another GPU-budget multiplier. Default **K=1 (off)** is the right safe default;
+  B2 at K=12+checkpoint roughly doubles train time × 3 models × seeds — a real monthly
+  cost. Favors B1.
+
+## 5. Key disagreements (the product)
+
+**D1 — Is the DGP chaotic, and does GTF's theory therefore apply?**
+*Sutton + Gneiting:* No — conflict counts aren't chaotic; the blow-up is `expm1`
+out-of-range drift, not Lyapunov divergence. Don't import GTF's α* bound as *theory*.
+*Hochreiter:* The **BPTT mechanism** (Jacobian-product growth) bites for *any*
+feedback operator with gain > 1 — which the diagnostic measured — independent of
+whether the DGP is formally chaotic. GTF's α-scaling is a general gradient-control
+tool, valid as a *heuristic* even if the chaos premise fails.
+*Merit/resolution:* Both right at different levels (theory vs mechanism). **B1
+sidesteps it** (no deep BPTT). If escalating to B2, use α as pragmatic gradient
+control (clip-like), **not** as a correctness guarantee — and fetch Mikhaeil 2022 to
+settle whether the bound is even meaningful here.
+
+**D2 — Is B1 sufficient, or is B2 necessary?**
+*DL-engineer + Sutton:* B1 first — cheap, general, flat memory, likely enough.
+*Hochreiter:* B1 trains only *one-step-back* stability; the runaway **compounds** over
+many steps and truncated K=12 gives biased gradients for the 24–36 tail — B1 may
+certify the wrong horizon.
+*Merit/resolution:* Pre-register the falsifier — B1 wins iff the io-gain attractor is
+in-range **and** step-wise CRPS is bounded through **all 36** steps (not just ≤K). If
+bounded at K but divergent past K → escalate to B2.
+
+**D3 — Proper score vs stability regulariser.**
+*Gneiting:* The stability term corrupts the proper score; anneal it →0, report CRPS
+clean; and point-stability is the wrong target — calibration is.
+*Pragmatic camp (DL-engineer, implicitly Brandstetter):* A small fixed weight
+empirically works (Brandstetter's results).
+*Merit/resolution:* Gneiting is theoretically correct and cheap to honor — **anneal
+the weight, keep CRPS + calibration as the uncontaminated headline.** No real tension
+once annealed.
+
+**D4 — Keep recurrence vs drop it (N-BEATS direct multi-horizon).**
+*Shi + Hochreiter + Gneiting:* Keep — ConvLSTM encodes the right spatiotemporal bias,
+nowcasting proves rollout training works on it, and N-BEATS (held) is a *point*
+forecaster that would regress the probabilistic objective.
+*Sutton:* At least *know* the direct-multi-horizon baseline number; a big direct model
++ compute might beat the engineered recurrence fix.
+*Merit/resolution:* Keep recurrence (3-to-1, and the probabilistic-objective argument
+is decisive). Sutton's ask is cheap and fair: record a direct baseline for expectation
+calibration, but it is **not** the path.
+
+**D5 — Does rollout training help or hurt the *chronic* problem? (shared caution)**
+*Shi + Gneiting (aligned, against the design's implicit optimism):* Multi-step
+optimisation encourages mean-hedging/blurring → could **worsen** sharpness and the
+zero-rate/MCR (ADR-057). Fixing point-stability is not obviously progress on
+calibration.
+*Resolution:* This is the **strongest dissent to keep live** — the readout must track
+MCR/zero-rate/coverage, and "C-113 solved" must not be declared on attractor magnitude.
+
+## 6. Synthesis & recommendation
+
+**Build, in this order:**
+
+1. **Kill `freeze_h` now** (unanimous; Sutton on principle, Operational on process):
+   set `freeze_h="none"`, remove the inference-time state-freeze — **gated** by the
+   parity guard + a golden_hour re-eval. Independent of everything below.
+2. **Verify `seq_len` vs 36 first** (Sutton's cheap lever): if the training window is
+   shorter than the inference rollout, *lengthening the window* is the most general,
+   least-clever rollout training and may dominate the fancy options. Cheap to check;
+   do it before implementing a loss term.
+3. **Implement B1 pushforward behind `rollout_horizon` (K=1 default)** — smallest diff
+   (we already detach), flat memory, beats noise injection (Brandstetter). With:
+   - **annealed/small stability-loss weight; CRPS reported uncontaminated** (Gneiting);
+   - **a readout that includes PIT/coverage + MCR/zero-rate + per-step CRPS through all
+     36 steps**, not just the io-gain attractor magnitude (Gneiting + Shi);
+   - **a cheap dose-response** (K∈{1,5,12} × weight on the proxy) before a full retrain
+     (DL-engineer).
+4. **Escalate to B2 GTF only on a pre-registered B1 failure** (bounded at K, divergent
+   past K). Then: α as *gradient control* not chaos theory (Sutton/Gneiting), **add
+   gradient clipping** (Hochreiter), **measure peak memory at K=12 + checkpoint**
+   (DL-engineer), interpolate **in the model's input space** (Shi), and fetch Mikhaeil
+   2022 to check the premise.
+5. **B3 Professor Forcing stays catalogued** — revisit only if calibration stays
+   broken after point-stability is fixed (i.e. if D5's caution materialises and B1/B2
+   don't address the *distributional* mismatch).
+6. **Sequence the whole program after the C-111 balancer verdict closes**
+   (Operational) — don't tune rollout HPs while the acute trigger is unattributed.
+
+**What's methodologically missing in `02_design` (fold in before pre-registration):**
+gradient clipping (Hochreiter); the calibration/sharpness readout + the
+proper-score-quarantine made concrete (Gneiting); the explicit feedback-space
+specification (Shi); measured (not asserted) K=12 memory + checkpoint plan
+(DL-engineer); the `seq_len`-vs-36 check + a direct-multi-horizon baseline number
+(Sutton); the chaos-premise check promoted from open-question to B2-blocker.
+
+**Strongest dissent to keep live (D5):** *fixing the point-trajectory runaway may not
+fix — and could worsen — the calibration/zero-rate problem the model also has.*
+Carry it into the pre-analysis plan as a falsifier, not a footnote.
+
+**Verdict:** the design is **sound and graduates toward ADR-058** — the layer is
+right, the ordering (B1→B2→B3) is right, freeze_h-kill is right. It is **not yet
+ready for an experiment** until the readout is upgraded to measure calibration (not
+just magnitude), the proper-score quarantine is operationalised, and the
+chaos-premise + seq_len checks are done.
+
+## 7. Methodological risks (register-compatible — for `register-risk`, not appended here)
+
+| ID | Tier | Title | Trigger | Location | Narrative |
+|----|------|-------|---------|----------|-----------|
+| **M-RT1** | 2 | Stability term corrupts the proper score | Implementing B1/B2 with a fixed nonzero `L_stability` weight and reporting CRPS as the headline | `02_design` §7–8; `training_engine` loss assembly | Pushforward/GTF terms are regularisers, not proper scoring rules (Gneiting & Raftery 2007). A fixed weight moves the optimiser off the true predictive distribution — stability bought by bias. Must anneal→0 / keep small and report CRPS uncontaminated. |
+| **M-RT2** | 2 | Truncated-horizon blindness (K<36) | Choosing K=12 and declaring stability from a ≤K readout | `02_design` §5 | TBPTT to K gives biased gradients and no stability certification for steps K+1…36; the runaway compounds in the tail. Either K=36 (checkpointed) or a falsifier that explicitly checks steps 13–36. |
+| **M-RT3** | 3 | Chaotic-DS theory imported without establishing λ_max>0 | Adopting B2 and setting α via the σ̃_max bound as a correctness guarantee | `02_design` §4.2, §9-Q1 | GTF's `α*=1−1/σ̃_max` bound is justified only for chaotic systems (Hess/Mikhaeil 2022, not held). The conflict DGP is likely non-chaotic; the explosion is `expm1` out-of-range drift. Use α as heuristic gradient control, not theory; fetch Mikhaeil 2022. |
+| **M-RT4** | 2 | Point-stability ≠ calibration (success-metric conflation) | First rollout-training experiment using only `diagnose_io_gain` as the readout | `02_design` §8–9; links ADR-057 | The runaway is a point/mean pathology; MCR is a calibration pathology. Fixing the attractor magnitude can leave — or worsen (mean-hedging/blurring) — calibration. Readout must include PIT/coverage + MCR/zero-rate, else "C-113 solved" is a category error. |
+| **M-RT5** | 3 | `freeze_h` removal changes production inference path unguarded | Setting `freeze_h="none"` globally before re-evaluating golden_hour models | `02_design` §3 (Element 1); `hydranet_inference.py` | Removing the inference-time state-freeze alters the path for every model. Gate behind the `rollout_horizon=1` parity guard + a per-model golden_hour re-eval before merge. |
+| **M-RT6** | 3 | New HPs interact with the open C-111 balancer instability | Enabling rollout training while the balancer freeze/active sweep is unresolved | `02_design` §9-Q4; ties C-111/C-124 | Stability-weight + K are tuned atop an already-unstable balancer; simultaneous unstable knobs confound attribution. Sequence after the balancer verdict. |
+
+*(Tiers are proposals; `register-risk` owns final tiering, dedup, and linking — M-RT4
+likely links the chronic-MCR cluster; M-RT5/6 link C-113/C-111/C-124.)*

--- a/reports/preanalysis_balancer_benefit.md
+++ b/reports/preanalysis_balancer_benefit.md
@@ -1,0 +1,58 @@
+# Pre-Analysis Plan — Does the MultiTaskLoss balancer earn its place? (C-124 / C-113 acute)
+
+**Date:** 2026-06-05 (pre-registered *before* the evals) · **Risk:** C-124 (benefit unverified), C-113 (acute fix), C-111 (the un-freeze)
+**Source of the question:** `expert-method-review` panel (Sutton/Harrell dissent) — *prove the learnable balancer beats frozen on skill before regularising it.*
+**Precedes:** the choice among regularisation options A–E. **Builds on:** `results_balancer_bisect.md` (measured stability, not skill); the `mtloss.py` audit (loss is faithful to Kendall 2018 — the runaway is an optimization-trajectory effect, not a loss bug).
+
+---
+
+## 1. Hypothesis
+**H (skeptics' default):** the *active* (learnable) balancer does **not** improve held-out predictive skill over the *frozen* (equal-weight) balancer; in the 36-step autoregressive setting it **destabilises** (out-of-range attractor → exploded CRPS). If so, the acute fix is simply **ship frozen** — A–E (regularisation) become unnecessary.
+
+## 2. Intervention (the ONE variable)
+`freeze_multitask_balancer ∈ {True (frozen), False (active)}`. Everything else held constant. **Stage 1 needs no retraining** — the bisect already produced device-matched GPU artifacts for both arms (violet, seed 42): frozen `calibration_model_20260605_051634.pt`, active `calibration_model_20260604_233938.pt`.
+
+## 3. Skepticism ledger
+- The active artifact is *already known* (from the attractor diagnostic) to be out-of-range — so its eval CRPS will likely explode. That confirms "active loses" but does **not** test "would a *stable* active balancer beat frozen" (that's Stage 2, conditional).
+- Single seed (violet/42). Robustness needs a 2nd seed (blue).
+- Frozen could carry a *hidden skill cost* the attractor can't see (it only showed in-range, not "as good as active would be if stable") — F2 guards this.
+- Evals exit 137 (post-metric OOM, C-116) — metrics dump before the kill; treat 137 as expected, read the wandb summary.
+
+## 4. Pre-registered predictions (step-wise CRPS, primary `lr_sb_best`; healthy ≈ 0.1)
+| Arm | artifact | prediction |
+|-----|----------|-----------|
+| **FROZEN** | 051634 | **healthy / in-range** (lr_sb CRPS < 1; lr_ns,os healthy) |
+| **ACTIVE** | 233938 | **exploded** (lr_sb CRPS ≫ 1e3) |
+⇒ the unregularised active balancer **does not earn its place**; frozen wins.
+
+## 5. Falsifiers (pre-committed)
+- **F1** — ACTIVE evals healthy/in-range ⇒ the diagnostic was misleading or the explosion is seed-fragile ⇒ rethink (the active artifact's attractor said ~log 16; this would contradict it).
+- **F2** — FROZEN is materially *worse* than the s0/pink healthy reference (not just in-range but low-skill) ⇒ the balancer's reweighting *was* doing useful work ⇒ escalate to **Stage 2** (regularised-active).
+- **F3** — both healthy and comparable ⇒ balancer is skill-neutral ⇒ **freeze for simplicity** (Occam/Sutton).
+
+## 6. Method
+- **Stage 1 (cheap, no retrain):** `--evaluate --saved` on the two existing violet artifacts; capture wandb CRPS/MCR + (for FROZEN) calibration/zero-rate. One model at a time on the (now free) GPU; ~40 min each.
+- **Stage 2 (conditional — only if F2 or a principled need for adaptive weighting):** implement **B (lower-LR for the log_var group)** or **E (warmup-then-unfreeze)** behind a flag (TDD), retrain active-regularised on GPU, eval, compare to frozen. *(A/D deprioritised — redundant with the existing `+log σ` regulariser, per the audit.)*
+- **Robustness:** repeat Stage 1 on **blue_stranger** (2nd exploder/seed) — needs a blue frozen retrain (the GPU-enforced driver) + its active baseline.
+
+## 7. Decision rules
+- **Predictions hold (frozen healthy, active exploded):** **ship frozen** as the C-113 acute fix; mark C-124 resolved ("balancer does not earn its place in the autoregressive setting; equal weighting is the stable, no-worse choice"). Skip A–E. Confirm on blue before final adoption.
+- **F2 fires:** go to Stage 2 (regularise B/E), because frozen costs skill.
+- **F1 fires:** the explosion is not reliably balancer-driven on this artifact ⇒ re-open the diagnosis.
+- Any outcome → log in the register / a results doc; negative results recorded plainly.
+
+---
+
+## Stage 1 RESULT (2026-06-05) — frozen is healthy; prediction confirmed (single seed)
+
+Evaluated the frozen violet artifact (`051634`); active is the known prior eval (2.13e17).
+
+| head | FROZEN step-wise CRPS | MCR | ACTIVE (known) |
+|------|----------------------:|----:|----------------|
+| lr_sb | **0.197** | 2.18 | 2.13e17 |
+| lr_ns | **0.043** | 0.97 | 2.78e9 |
+| lr_os | **0.052** | 0.20 | 54.5 |
+
+**Prediction confirmed** (frozen healthy/in-range, comparable to the pink reference ~0.13/0.03/0.05; active exploded). **F1/F3 did not fire. F2 did not fire** — frozen `lr_sb` 0.197 is mildly above pink's 0.13 but within known seed variance and clearly healthy; freezing did not cripple skill. ⇒ the learnable balancer **does not earn its place** here; **freeze is the acute fix** (no A–E regularisation).
+
+**Caveat → upgraded validation:** single seed (violet/42). Rather than a single blue confirm, validation is upgraded to a **3-seed × 2-balancer-state sweep** — see `preanalysis_balancer_sweep.md`. C-124 stays open pending that sweep; on confirmation, freeze ships and C-124 resolves.

--- a/reports/preanalysis_balancer_sweep.md
+++ b/reports/preanalysis_balancer_sweep.md
@@ -1,0 +1,59 @@
+# Pre-Analysis Plan — Balancer × Seed sweep (C-124 / C-113 acute, multi-seed confirmation)
+
+**Date:** 2026-06-05 (pre-registered *before* the sweep) · **Risk:** C-124, C-113, C-111
+**Upgrades:** the single-seed Stage-1 result in `preanalysis_balancer_benefit.md` (frozen healthy, active exploded, violet/42) to a **multi-seed factorial**, killing the single-seed caveat.
+
+---
+
+## 1. Hypothesis
+**H:** The C-111 active MultiTaskLoss balancer is a **reliable, seed-independent blow-up lever**: across seeds, *active* → out-of-range free-running attractor (runaway), *frozen* → in-range (stable). If so, `freeze_multitask_balancer=True` is the robust acute fix for C-113 and the learnable balancer does not earn its place.
+
+## 2. Design (the ONE base config; vary only seed × balancer)
+**3 × 2 factorial = 6 from-scratch trains**, all on the **violet base config** (isolates the two variables; not confounded by pink/blue's other config diffs):
+- **seed** ∈ {42, 4, 99} (the project's three seeds; set `np_seed = torch_seed = seed`)
+- **`freeze_multitask_balancer`** ∈ {False (active), True (frozen)}
+
+## 3. Readout
+Per fresh artifact: **`scripts/diagnose_io_gain.py`** free-running attractor (retrain-free, ~30 s) — in-range (≲ log 13) vs out-of-range (≳ log 20). This is the validated proxy (matched the real eval for pink/violet). Optional: a confirmatory `--evaluate` on the frozen cells for real CRPS.
+
+## 4. Pre-registered predictions
+| | seed 42 | seed 4 | seed 99 |
+|---|---|---|---|
+| **active** | out-of-range | out-of-range | out-of-range |
+| **frozen** | in-range | in-range | in-range |
+(3/3 active explode; 3/3 frozen stable.)
+
+## 5. Falsifiers (pre-committed)
+- **F1 — active not always explosive:** ≥1 active cell is in-range ⇒ the explosion is **seed-conditional**, not a deterministic balancer effect ⇒ "freeze always" is over-strong; the active balancer is sometimes fine ⇒ nuance the fix (freeze as safe default, active opt-in).
+- **F2 — frozen not always stable:** ≥1 frozen cell is out-of-range ⇒ **freezing is not sufficient** ⇒ the balancer is not the sole cause ⇒ re-open the diagnosis (other driver).
+- **F3 — diagnostic vs reality:** if a confirmatory eval on a frozen cell explodes despite an in-range attractor ⇒ the proxy is unfaithful for that artifact ⇒ trust the eval.
+
+## 6. Method
+- GPU-enforced driver (CUDA pre-flight gate + on-GPU PID verification — no silent CPU fallback, C-115); one model at a time (~80 min each → ~8 h total); config trap-restored after each cell and at exit.
+- Capture the newest artifact per cell; run `diagnose_io_gain` on it; record to `logs/balancer_sweep_RESULTS.txt`.
+- Seeds set via `np_seed`/`torch_seed`; balancer via `freeze_multitask_balancer`.
+
+## 7. Decision rules
+- **3/3 active explode + 3/3 frozen in-range (predicted):** robust confirmation ⇒ **ship `freeze_multitask_balancer=True`** as the C-113 acute fix across the golden_hour models; **resolve C-124** ("balancer does not earn its place; equal weighting is the stable, no-worse choice"); close the C-113 acute track (chronic ZITD work continues separately).
+- **F1:** freeze is a safe default but document the seed-conditionality; consider active-opt-in.
+- **F2:** re-open — freezing insufficient; the balancer is not the (sole) cause.
+- Any outcome logged; negatives recorded plainly.
+
+---
+
+## RESULT (2026-06-05) — **F2 FIRED**: freezing is seed-fragile → re-open
+
+Sweep `20260605_132248`, **5/6 cells** (`seed99_frozen` crashed: `CUDA error: unspecified launch failure` — almost certainly the lid-suspend `nvidia_uvm` wedge, not a model failure; train_exit=1, no artifact). Readout = `diagnose_io_gain` free-running attractor on **synthetic** seeds (noisy — intra-cell verdicts flip across U[0,s] seeds, so read the `inf`/out-of-range explosions, not the borderline rows).
+
+| | active | frozen |
+|---|---|---|
+| **seed 42** (bisect, reused) | PATHOLOGICAL ~log16 | healthy ~log4–5 |
+| **seed 4** | PATHOLOGICAL (≤~log14.5; 2e5–7e5) | **PATHOLOGICAL → `inf`** (step48 ~9.5k in log) |
+| **seed 99** | **PATHOLOGICAL → `inf`** | — (CUDA crash, no artifact) |
+
+- **Active: 3/3 explode** — prediction held; the active balancer reliably destabilises.
+- **Frozen: NOT 3/3 stable** — seed 42 healthy, but **`seed4_frozen` exploded to `inf`** (*worse* than `seed4_active`), seed 99 missing. **F2 fired.**
+
+**Verdict (per §5/§7): F2 — freezing is not sufficient; the balancer is not the sole cause ⇒ re-open the diagnosis.** "Ship `freeze_multitask_balancer=True` as the robust acute fix" is **falsified** — freezing is seed-fragile and on seed 4 actively harmful. Corroborates the chronic train/inference **exposure-bias** mismatch (Axis-B rollout training, register **C-125**; `reports/2026-06-05_rollout_training_dossier/`) as the root, with the balancer one trigger among seeds. **C-124 stays OPEN** (does *not* resolve as "freeze ships").
+
+**Follow-ups:** (a) optionally re-run `seed99_frozen` after clearing the CUDA/`nvidia_uvm` wedge to complete the factorial — *the F2 conclusion is already robust without it*; (b) the durable fix is the rollout-training program, sequenced per C-125/C-126.

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -5,8 +5,8 @@
 | Project           | views-hydranet                       |
 | Owner             | Simon Polichinel von der Maase       |
 | Last Updated      | 2026-06-05                           |
-| Total Concerns    | 121                                  |
-| Open Concerns     | 27                                   |
+| Total Concerns    | 124                                  |
+| Open Concerns     | 30                                   |
 | — of which demoted (tech-debt) | 4 (tagged `[DEMOTED]` in §Open Concerns; indexed in §Tech-Debt Backlog) |
 | Resolved Concerns | 94                                   |
 
@@ -324,9 +324,9 @@ Tier 2 rationale (recalibrated 2026-06-05): this is a **silent-miscalibration** 
 | Source | review (PR #64, 2026-06-03) |
 | Trigger | When comparing CRPS/MCR (or any post-training metric) between a model trained before the C-111 merge and one trained after — or when assembling an ensemble whose members straddle the merge boundary — attributing the difference to anything other than the now-active balancer is unsound |
 | Location | `views_hydranet/train/training_engine.py:make()` (optimizer param groups), model artifacts in `views-models/models/*/data/generated/` |
-| Cross-refs | C-111 (resolved — the fix), C-79 (no pipeline reproducibility test) |
+| Cross-refs | C-111 (resolved — the fix), C-79 (no pipeline reproducibility test), C-124/C-125 (rollout × balancer confound) |
 
-The C-111 fix makes the MultiTaskLoss balancer actually learn, which changes trained weights for every run after the merge. Concretely: the golden_hour ensemble evaluated 2026-06-03 (constituents trained pre-fix, sb CRPS 0.1298 / MCR 0.300) is a pre-C-111 baseline. A post-fix retrain will differ, and the difference will conflate (a) the balancer effect with (b) ordinary run-to-run variance (the sweep showed substantial variance: pink_pirate sb MCR ranged 0.029–0.552 across seeds). Any pinned golden-number assertion on post-training metrics would also need re-baselining. The risk is methodological: drawing a causal "C-111 improved X" conclusion from a single pre/post pair, or silently mixing pre- and post-fix artifacts in one ensemble.
+The C-111 fix makes the MultiTaskLoss balancer actually learn, which changes trained weights for every run after the merge. Concretely: the golden_hour ensemble evaluated 2026-06-03 (constituents trained pre-fix, sb CRPS 0.1298 / MCR 0.300) is a pre-C-111 baseline. A post-fix retrain will differ, and the difference will conflate (a) the balancer effect with (b) ordinary run-to-run variance (the sweep showed substantial variance: pink_pirate sb MCR ranged 0.029–0.552 across seeds). Any pinned golden-number assertion on post-training metrics would also need re-baselining. The risk is methodological: drawing a causal "C-111 improved X" conclusion from a single pre/post pair, or silently mixing pre- and post-fix artifacts in one ensemble. **The same attribution hazard extends forward (folds M-RT6):** enabling Axis-B rollout training (C-125) while the balancer freeze/active question (C-124) is still open would tune two unstable training-dynamics knobs at once and confound which fixed the runaway — sequence the rollout work *after* the balancer verdict closes.
 
 Tier 4 rationale: no correctness impact on any single run — each model is internally valid. The risk is interpretation/comparison hygiene, single-developer scope. Mitigation: when measuring the C-111 effect, retrain all members under identical seeds and compare, ideally with >1 seed to separate signal from variance.
 
@@ -352,6 +352,10 @@ Tier 2 rationale: structural fragility with a confirmed, realistic trigger (it a
 **Update 2026-06-04 — diagnosis sharpened (two empirical results):** (1) ADR-057 (consistent-mask dropout) was **FALSIFIED** — violet still exploded under locked masks (`reports/postmortem_locked_dropout_negative_result.md`); the driver is the deterministic recurrence, not dropout noise. (2) A pre-registered `freeze_h` 2×2 ablation (`reports/results_freezeh_ablation.md`) localized the channel: **all four `freeze_h` modes explode within ~½ order of magnitude on `lr_sb` (2.1–7.0 ×10¹⁷), including `all` (entire recurrent hidden/cell state frozen → 5.13e17).** Therefore the divergence is **not** carried by the recurrent hidden-to-hidden dynamics but by the **prediction→input feedback loop** (the model's gain on its own fed-back prediction > 1). Consequences: `freeze_h` (shipped as `"hl"` in all configs) is **inert** against this failure and is a candidate for retirement (it also creates a train/inference mismatch — training evolves the full state, inference freezes `hl`); the **ADR-028 §2 cell-state clamp is pre-falsified** (`freeze_h="all"` is its extreme and failed); the correct fix targets the **input→output map** — spectral-norm/Lipschitz on the input-to-hidden `Wx*` + U-Net encoder/decoder convs, pushforward/GTF training, and/or an in-domain feedback-input clamp (magnitude-neutral). See `reports/options_catalogue_autoregressive_stability.md` §0 UPDATE. **Axis-0 diagnostic run** (`reports/results_io_gain_diagnostic.md`, `scripts/diagnose_io_gain.py`): standalone retrain-free rollout reproduces the explosion — violet's free-running input→output map settles at an **out-of-range attractor (~log 40 → `expm1` ≈ 1e17, matching the observed CRPS)** while pink stays in-range (~log 10), **state-independently**. The local operator norm `‖∂reg/∂x‖₂` does *not* discriminate (both >1); the discriminator is the attractor level vs data range. **In-domain feedback clamp — TESTED (`reports/results_feedback_clamp.md`):** clamping the fed-back prediction per-target to the log1p data max (`feedback_clamp_log1p`, inference-only) **averts the catastrophe** (violet `lr_sb` 2.13e17 → 798; `lr_ns`/`lr_os` recover to healthy; benign on pink) but is a **safety rail, not a resolution** — it triggers falsifier F2 for `lr_sb` (ramps to the ceiling and pins → MCR ~56,000 over-prediction). C-113 stays **OPEN**; the clamp is retained as an optional guard rail (`feedback_clamp_log1p`, default None=off). Durable fix still required: lower the input→output attractor (spectral-norm/Lipschitz on input→output path, pushforward/GTF, or count-likelihood head).
 
 **Update 2026-06-05 — ACUTE CAUSE FOUND (C-111 balancer bisect, `reports/results_balancer_bisect.md`):** a pre-registered, device-matched (GPU/GPU) bisect on violet found the driver: **the C-111 fix (un-freezing the MultiTaskLoss `log_vars`) is what causes the runaway.** Frozen-balancer retrain settles in-range (free-running attractor log ~4–5 → `expm1` ~1e2); active-balancer control diverges (log ~15–17 → ~1e7) — ~5 orders apart. So the acute explosion is a **C-111 regression**, not a fundamental flaw (the model was stable for years with the balancer effectively frozen). **Fix direction: regularise the balancer (bound/decay `log_vars`, lower its LR), not permanent freeze** — `freeze_multitask_balancer=True` is the safe immediate fallback / the bisect's extreme. Caveat: single seed each (C-112/C-119) — confirm on ≥1 more seed + a real `--evaluate` before production. The **chronic** problem (MCR≪1, no calibrated uncertainty) is orthogonal and still motivates the ZITD distributional-head dossier. `freeze_h` (inert) and the in-domain clamp (bounded-but-degenerate) were both *downstream* of this cause.
+
+**`mtloss.py` audited (2026-06-05, expert-method-review):** the `MultiTaskLoss` is faithful to Kendall 2018 — the `+log σ` self-regularising term (`+ torch.log(stds)`) is **present and correctly signed**, and the per-task coefficients match (`1/2σ²` regression, `1/σ²` classification). So the runaway is **not** a loss-spec bug (hypothesis "M2" cleared); it is the **optimization-trajectory effect** of the active reweighting steering training into a divergent-recurrence basin. Fix direction therefore shifts *away from* adding a prior/decay (redundant with the existing regulariser) *toward* slowing/scheduling the reweighting (lower-LR / warmup) or freezing — pending the benefit check in C-124.
+
+**Update 2026-06-05 — durable fix designed + `freeze_h` retirement gated (expert-method-review, rollout dossier):** the durable fix is now designed as **Axis-B rollout training** (`reports/2026-06-05_rollout_training_dossier/`, ADR-058 candidate; see C-125/C-126) — train the prediction→input feedback operator (the runaway carrier) that is currently detached at `training_engine.py:200`. Retiring the (inert) inference-time `freeze_h` changes the inference path for *every* model, so it must be **gated** behind a `rollout_horizon=1` parity guard + a per-model golden_hour re-eval before merge — not flipped globally blind (folds method-review finding M-RT5). **Characterization gate PASSED 2026-06-05** (`views-models/logs/freezeh_pink_eval_*.log`): pink_pirate evaluated on its existing artifact with the freeze_h-removed path (always-`none`) reproduces the healthy reference to ~3 d.p. — step-wise CRPS lr_sb **0.133** / lr_ns **0.031** / lr_os **0.051** (ref ~0.13/0.03/0.05), MCR healthy. ⇒ removal is non-regressing; M-RT5 cleared. (Branch `chore/retire-freeze-h`: method + config field + 5 capability tests removed; ADR-027/CIC updated; ruff + 699 tests + validate_docs green.)
 
 ---
 
@@ -534,6 +538,61 @@ Tier 3 rationale: maintainability/governance gap that raises the cost and risk o
 `choose_loss` returns three losses as a positional tuple; consumers must *know* index 2 is the `MultiTaskLoss` balancer (the C-111 epicenter). A named structure (dataclass `reg`/`cls`/`balancer`) would remove the positional coupling. Low impact today (callers are internal and tested), but the ZITD head — which replaces the reg+cls pair with one likelihood — is exactly the change that would reshuffle the tuple.
 
 Tier 4 rationale: code-quality/readability; internal, tested callers; no correctness or reliability impact today. Flagged because the imminent ZITD change touches it.
+
+---
+
+### C-124: MultiTaskLoss balancer's predictive benefit is unverified — known to destabilise, not known to help
+
+| Field | Value |
+|-------|-------|
+| ID | C-124 |
+| Tier | 3 |
+| Source | expert-method-review (2026-06-05) |
+| Trigger | Choosing/keeping a balancer regularisation (or re-enabling the active balancer) before comparing frozen vs active on CRPS/MCR/calibration, held-out, ≥1 extra seed |
+| Location | `views_hydranet/train/training_engine.py` (the log_var optimizer param group); `reports/results_balancer_bisect.md` (measured *stability*, not *skill*) |
+| Cross-refs | C-111 (the balancer un-freeze), C-112 (pre/post comparability), C-113 (the runaway) |
+
+The C-111 bisect established the active balancer **destabilises** the autoregressive dynamics (out-of-range attractor) but **never measured whether it improves predictive skill** vs the frozen (equal-weight) baseline. Regularising or re-enabling the balancer therefore risks engineering a fix for a component whose benefit is unverified — and per the panel's strongest dissent (Sutton/Harrell), **"ship frozen" may be the correct endpoint, not a fallback.** The `mtloss.py` audit (see C-113 update) cleared the loss as a defect, so the runaway is an *optimization-trajectory* effect of the active reweighting — which makes "is the reweighting worth its fragility?" the live empirical question.
+
+Tier 3 rationale: methodology / decision-hygiene gap that could mis-direct the acute fix; no silent corruption. Mitigation: a **pre-registered frozen-vs-active CRPS/MCR comparison (≥1 seed)** before choosing among the regularisation options. *(Audit note: the sibling hypothesis "M2 — Kendall-loss mis-implementation" was checked and **cleared** — `mtloss.py` is faithful to Kendall 2018 — so it is recorded in the C-113 update rather than registered as an open defect.)*
+
+**Stage-1 result (2026-06-05, `preanalysis_balancer_benefit.md`):** the FROZEN violet artifact evaluates **healthy** (step-wise CRPS lr_sb 0.197 / lr_ns 0.043 / lr_os 0.052, ~ the pink reference) while ACTIVE is the known 2.13e17 explosion ⇒ the balancer does **not** earn its place; **freeze is the acute C-113 fix**. Single seed (violet/42) — validation upgraded to a **3-seed × 2-balancer-state sweep** (`preanalysis_balancer_sweep.md`); C-124 resolves on confirmation.
+
+**Update 2026-06-05 — sweep complete (5/6), F2 FIRED, freeze falsified as the fix:** the 3×2 seed×balancer sweep finished (`seed99_frozen` crashed on a CUDA wedge; 5/6 cells). **Active explodes 3/3** (prediction held), but **frozen is NOT robust**: `seed4_frozen → inf` (worse than `seed4_active`), seed 99 frozen missing. Per the pre-reg decision rules, **F2 fired → re-open: freezing is insufficient and the balancer is not the sole cause** (`reports/preanalysis_balancer_sweep.md` §RESULT). The "ship `freeze_multitask_balancer=True` as the robust acute fix" conclusion is **falsified** — freezing is seed-fragile and on seed 4 actively harmful. ⇒ the chronic train/inference **exposure-bias** mismatch (Axis-B rollout training, **C-125**) is the root; the balancer is one trigger among seeds. **C-124 stays OPEN** (does not resolve as "freeze ships"); the durable fix is the rollout-training program.
+
+---
+
+### C-125: Rollout-training (Axis B) procedure rests on three unverified methodological premises
+
+| Field | Value |
+|-------|-------|
+| ID | C-125 |
+| Tier | 3 |
+| Source | expert-method-review (2026-06-05, rollout-training dossier `02b`) |
+| Trigger | When implementing rollout training (B1 pushforward / B2 GTF) in `training_engine`, before merging — verify all three: (a) the `L_stability` weight is annealed/small and CRPS reported uncontaminated; (b) the stability readout certifies the **full 36-step** horizon, not just the K≤36 training window; (c) for B2, α is used only as heuristic gradient control unless `λ_max>0` is established for the conflict DGP |
+| Location | `reports/2026-06-05_rollout_training_dossier/02_design.md` §4.2/§5/§7/§8; `views_hydranet/train/training_engine.py` (loss assembly + the rollout loop) |
+| Cross-refs | C-113 (the runaway this fixes), C-124 (balancer benefit), C-112 (attribution confound), ADR-058 (candidate); folds method-review findings M-RT1/M-RT2/M-RT3 |
+
+The Axis-B design adds a multi-step rollout objective to fix the C-113 runaway. The method-review panel flagged three premises that, if unchecked, make the fix subtly wrong. **(a) Proper-score corruption (M-RT1, Gneiting)** — pushforward/GTF stability terms are *regularisers*, not proper scoring rules (Gneiting & Raftery 2007); a fixed nonzero weight moves the training optimum off the true predictive distribution, so the headline CRPS must stay uncontaminated and the weight annealed. **(b) Truncated-horizon blindness (M-RT2, Hochreiter)** — training/certifying to K=12 gives biased gradients and no stability guarantee for steps 13–36, where the runaway compounds; the readout must check the full horizon or a tail falsifier. **(c) Chaos-premise (M-RT3, Sutton/Gneiting)** — GTF's provable `α*=1−1/σ̃_max` bound is valid only for chaotic systems (Hess 2023 / Mikhaeil 2022, not held); the conflict DGP is likely non-chaotic (the explosion is `expm1` out-of-range drift), so α may serve only as heuristic gradient control, not a correctness guarantee.
+
+Tier 3 rationale: design-stage methodology gaps for an as-yet-unbuilt feature; no current silent corruption, but each could mis-direct the C-113 fix or ship a subtly biased forecaster. Mitigation: the pre-analysis plan (`05`) pre-registers (a)/(b)/(c) as binding guardrails + falsifiers before any full retrain; fetch Mikhaeil 2022 to settle (c). Promote to Tier 2 if rollout training is implemented without these guards.
+
+---
+
+### C-126: Rollout-training success metric conflates point-stability with calibration
+
+| Field | Value |
+|-------|-------|
+| ID | C-126 |
+| Tier | 3 |
+| Source | expert-method-review (2026-06-05, rollout-training dossier `02b`) |
+| Trigger | When evaluating the first rollout-training experiment — using the `diagnose_io_gain` free-running attractor magnitude as the sole success criterion, without also reporting PIT/coverage + MCR + zero-rate |
+| Location | `scripts/diagnose_io_gain.py`; `reports/2026-06-05_rollout_training_dossier/02_design.md` §8–9 |
+| Cross-refs | C-113 (point/mean runaway), C-110 (ensemble MCR calibration), ADR-057 + the ZITD distributional-head dossier (chronic MCR); folds method-review finding M-RT4 |
+
+The C-113 runaway is a *point/mean* pathology (the trajectory leaves the data range); the chronic problem (MCR≪1, no calibrated uncertainty) is a *calibration* pathology. The panel (Gneiting + Shi) warned these are independent: multi-step rollout optimisation rewards mean-hedging / regression-to-the-mean (a known ConvLSTM nowcasting failure), which can leave — or *worsen* — calibration and the zero-rate even as the attractor returns in-range. Declaring "C-113 resolved" on attractor magnitude alone would be a category error and could silently degrade the very metric the ZITD head exists to fix. This is the dossier's strongest live dissent (D5), carried forward as a falsifier.
+
+Tier 3 rationale: evaluation/decision-hygiene gap; no silent corruption today, but it gates whether the rollout fix is genuinely progress. Mitigation: the rollout-training readout must include calibration (PIT/coverage) + sharpness (MCR/zero-rate) as first-class metrics, pre-registered in `05`.
 
 ---
 

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -5,8 +5,8 @@
 | Project           | views-hydranet                       |
 | Owner             | Simon Polichinel von der Maase       |
 | Last Updated      | 2026-06-05                           |
-| Total Concerns    | 124                                  |
-| Open Concerns     | 30                                   |
+| Total Concerns    | 125                                  |
+| Open Concerns     | 31                                   |
 | — of which demoted (tech-debt) | 4 (tagged `[DEMOTED]` in §Open Concerns; indexed in §Tech-Debt Backlog) |
 | Resolved Concerns | 94                                   |
 
@@ -593,6 +593,25 @@ Tier 3 rationale: design-stage methodology gaps for an as-yet-unbuilt feature; n
 The C-113 runaway is a *point/mean* pathology (the trajectory leaves the data range); the chronic problem (MCR≪1, no calibrated uncertainty) is a *calibration* pathology. The panel (Gneiting + Shi) warned these are independent: multi-step rollout optimisation rewards mean-hedging / regression-to-the-mean (a known ConvLSTM nowcasting failure), which can leave — or *worsen* — calibration and the zero-rate even as the attractor returns in-range. Declaring "C-113 resolved" on attractor magnitude alone would be a category error and could silently degrade the very metric the ZITD head exists to fix. This is the dossier's strongest live dissent (D5), carried forward as a falsifier.
 
 Tier 3 rationale: evaluation/decision-hygiene gap; no silent corruption today, but it gates whether the rollout fix is genuinely progress. Mitigation: the rollout-training readout must include calibration (PIT/coverage) + sharpness (MCR/zero-rate) as first-class metrics, pre-registered in `05`.
+
+---
+
+### C-127: Duplicate dict keys in model configs (F601) — later definition silently shadows the earlier
+
+| Field | Value |
+|-------|-------|
+| ID | C-127 |
+| Tier | 4 |
+| Source | tech-debt-cleanup (ruff F601, 2026-06-06) |
+| Trigger | Editing the *first* occurrence of one of these keys expecting it to take effect — Python keeps the *last* definition, so the earlier edit is silently dead |
+| Location | `views-models/models/{heavy_strider,light_strider,white_ranger}/configs/config_hyperparameters.py` (`skip_predictions_delivery` ×2); `views-models/models/new_rules/configs/config_sweep.py:124,130` (`expansion_coefficient_dim` ×2) |
+| Cross-refs | C-06 (config `extra="allow"` masks unknown keys) — distinct: F601 is linter-visible, not silent passthrough |
+
+Four model configs define a dict key twice; Python silently retains the last assignment. **Severity is Low because the values mostly agree:** all three `skip_predictions_delivery` duplicates are `True` (pure redundancy, no behavioural effect — the earlier "could change delivery" worry is *not* realised). The one real divergence is `new_rules` sweep `expansion_coefficient_dim`: line 124 `[64,128]` is dead, line 130 `[32,64,128]` wins — so the sweep search space is `[32,64,128]` regardless of the misleading earlier line. Sweep-scoped (hyperparameter search), not production delivery → no silent *output* corruption.
+
+Tier 4 rationale: linter-visible (ruff F601, not silent), values mostly identical, the one divergence affects only a sweep search space. Mitigation: delete the dead (earlier) duplicate in each file, preserving current behaviour; confirm `new_rules` intended `[32,64,128]`.
+
+**Fix applied 2026-06-06** (views-models `e9ced12`, pushed to `development`): the earlier (dead) duplicate removed in all four files, current behaviour preserved; ruff F601 clean repo-wide. Open pending merge to main; `new_rules`'s `[32,64,128]` kept as the effective value — author to confirm `[64,128]` was not the intent.
 
 ---
 

--- a/tests/test_falsification_loss_param_validation.py
+++ b/tests/test_falsification_loss_param_validation.py
@@ -12,7 +12,7 @@ class TestF5_CICFieldCountDrift:
 
     def test_cic_field_count_matches_actual(self):
         """CIC §3 field count must match actual model_fields count."""
-        CIC_CLAIMED_COUNT = 71  # from docs/CICs/HydraNetConfig.md §3
+        CIC_CLAIMED_COUNT = 70  # from docs/CICs/HydraNetConfig.md §3 (freeze_h retired 2026-06-05)
         actual = len(HydraNetConfig.model_fields)
         assert actual == CIC_CLAIMED_COUNT, (
             f"CIC §3 claims {CIC_CLAIMED_COUNT} fields but HydraNetConfig has {actual}. "

--- a/tests/test_inference_logic.py
+++ b/tests/test_inference_logic.py
@@ -1,112 +1,24 @@
-import pytest
-import torch
+"""Inference-path logic tests.
 
-from views_hydranet.architectures.HydraBNrecurrentUnet_06_LSTM4 import ModelOutput
+`freeze_h` was retired 2026-06-05 (see `reports/2026-06-05_rollout_training_dossier/`,
+ADR-027 update, register C-113). The autoregressive rollout now always evolves the full
+ConvLSTM state (the former `"none"` behaviour) — the only mode that did not create a
+train/inference mismatch, and the freeze was empirically inert against the C-113 runaway
+(which rides the prediction→input feedback path, not the recurrent state). The five
+`execute_freeze_h_option` capability tests were removed with the method; the guard below
+prevents silent reintroduction.
+"""
+
 from views_hydranet.utils.hydranet_inference import HydraNetInference
 
 
-class MockModel(torch.nn.Module):
-    def __init__(self, channels=64):
-        super().__init__()
-        self.base = 32
-        self.channels = channels
+def test_freeze_h_option_retired():
+    """Regression guard: the freeze_h hack must not be reintroduced.
 
-    def forward(self, x, h):
-        # Update h by adding x (simulated update)
-        h_new = h + 0.1
-        # Dummy predictions
-        reg = torch.randn(x.shape[0], 3, x.shape[2], x.shape[3])
-        cls = torch.randn(x.shape[0], 3, x.shape[2], x.shape[3])
-        return ModelOutput(reg=reg, cls=cls, h_next=h_new)
-
-
-@pytest.fixture
-def inf_setup():
-    model = MockModel(channels=64)
-    cfg = {
-        "freeze_h": "none",
-        "sampling_strategy": "threshold",
-        "time_steps": 1,
-        "steps": [1],
-        "regression_targets": ["r1", "r2", "r3"],
-        "classification_targets": ["c1", "c2", "c3"],
-        "features": ["f1", "f2"],
-    }
-    inf = HydraNetInference(model, cfg, device="cpu")
-    return inf, model
-
-
-def test_freeze_h_none(inf_setup):
-    inf, model = inf_setup
-    inf.config["freeze_h"] = "none"
-
-    h = torch.zeros(1, 64, 4, 4)
-    x = torch.randn(1, 2, 4, 4)
-
-    _, _, h_out = inf.execute_freeze_h_option(x, h)
-
-    # Should be fully updated
-    assert torch.allclose(h_out, h + 0.1)
-
-
-def test_freeze_h_all(inf_setup):
-    inf, model = inf_setup
-    inf.config["freeze_h"] = "all"
-
-    h = torch.zeros(1, 64, 4, 4)
-    x = torch.randn(1, 2, 4, 4)
-
-    _, _, h_out = inf.execute_freeze_h_option(x, h)
-
-    # Should NOT be updated
-    assert torch.allclose(h_out, h)
-
-
-def test_freeze_h_hl(inf_setup):
-    inf, model = inf_setup
-    inf.config["freeze_h"] = "hl"
-
-    h = torch.zeros(1, 64, 4, 4)
-    x = torch.randn(1, 2, 4, 4)
-
-    _, _, h_out = inf.execute_freeze_h_option(x, h)
-
-    # First half (hs) updated, second half (hl) frozen
-    assert torch.allclose(h_out[:, :32], h[:, :32] + 0.1)
-    assert torch.allclose(h_out[:, 32:], h[:, 32:])
-
-
-def test_freeze_h_hs(inf_setup):
-    inf, model = inf_setup
-    inf.config["freeze_h"] = "hs"
-
-    h = torch.zeros(1, 64, 4, 4)
-    x = torch.randn(1, 2, 4, 4)
-
-    _, _, h_out = inf.execute_freeze_h_option(x, h)
-
-    # First half (hs) frozen, second half (hl) updated
-    assert torch.allclose(h_out[:, :32], h[:, :32])
-    assert torch.allclose(h_out[:, 32:], h[:, 32:] + 0.1)
-
-
-def test_freeze_h_random(inf_setup):
-    inf, model = inf_setup
-    inf.config["freeze_h"] = "random"
-
-    h = torch.zeros(1, 64, 4, 4)
-    x = torch.randn(1, 2, 4, 4)
-
-    # Run multiple times to ensure we see both states (probabilistic)
-    results = []
-    for _ in range(20):
-        _, _, h_out = inf.execute_freeze_h_option(x, h)
-        results.append(h_out)
-
-    # Check that for each chunk of 8 channels, it's either 0 or 0.1
-    for res in results:
-        for i in range(8):
-            chunk = res[:, i * 8 : (i + 1) * 8]
-            is_old = torch.allclose(chunk, torch.zeros_like(chunk))
-            is_new = torch.allclose(chunk, torch.zeros_like(chunk) + 0.1)
-            assert is_old or is_new
+    `execute_freeze_h_option` was deleted when freeze_h was retired; if it reappears,
+    the durable fix (Axis-B rollout training) is being bypassed by a hard-prior hack.
+    """
+    assert not hasattr(HydraNetInference, "execute_freeze_h_option"), (
+        "execute_freeze_h_option was retired (2026-06-05) — the rollout evolves the "
+        "full state. Reintroducing it reinstates the inference-time freeze hack."
+    )

--- a/views_hydranet/utils/config_initializer.py
+++ b/views_hydranet/utils/config_initializer.py
@@ -127,7 +127,6 @@ class HydraNetConfig(BaseModel):
     roof_ratio: float = Field(...)
     max_ratio: float = Field(...)
     min_ratio: float = Field(...)
-    freeze_h: str = Field(...)
     feedback_clamp_log1p: list[float] | None = Field(
         default=None,
         description=(

--- a/views_hydranet/utils/hydranet_inference.py
+++ b/views_hydranet/utils/hydranet_inference.py
@@ -23,9 +23,6 @@ class HydraNetInference:
     Monte Carlo Dropout for uncertainty estimation.
     """
 
-    _RANDOM_FREEZE_NUM_CHUNKS = 8
-    _RANDOM_FREEZE_PROBABILITY = 0.5
-
     def __init__(
         self,
         model: Module,
@@ -132,113 +129,6 @@ class HydraNetInference:
             return t0_autoreg
         ceiling = self.feedback_clamp.to(device=t0_autoreg.device, dtype=t0_autoreg.dtype)
         return torch.minimum(t0_autoreg, ceiling)
-
-    def execute_freeze_h_option(
-        self, t0: torch.Tensor, h_tt: torch.Tensor
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Handles the freezing of hidden state (`h_tt`) based on configuration.
-
-        This function selectively freezes short-term (`hs`) or long-term (`hl`) memory,
-        or both, based on the `config["freeze_h"]` setting.
-
-        Args:
-            t0: The input tensor for the current time step.
-            h_tt: The hidden state tensor.
-
-        Returns:
-            A tuple containing:
-                - t1_pred: Predicted magnitudes.
-                - t1_pred_class: Predicted probabilities (pre-sigmoid if frozen).
-                - h_tt: Updated (or partially frozen) hidden state.
-
-        Raises:
-            ValueError: If an invalid freeze_h option is provided.
-        """
-
-        freeze_h = self.config.get("freeze_h", "none")  # Default to "none" if key is missing
-
-        # Compute the split index
-        num_channels = h_tt.shape[1]
-        split_size = num_channels // 2  # Half the channels
-
-        if freeze_h == "hl":  # Freeze long-term memory (cell state)
-            logger.debug("Freezing long-term memory (hl).")
-
-            # Split `h_tt` into short-term (`hs_t`) and long-term (`hl_t`) components
-            _, hl_t_frozen = torch.split(h_tt, split_size, dim=1)
-
-            # Run the model
-            output = self.model(t0, h_tt)
-            t1_pred, t1_pred_class, h_tt = output.reg, output.cls, output.h_next
-
-            # Split the updated hidden state and keep the old `hl_t_frozen`
-            hs_t_updated, _ = torch.split(h_tt, split_size, dim=1)
-
-            # Concatenate the new `hs_t_updated` with the frozen `hl_t_frozen`
-            h_tt = torch.cat((hs_t_updated, hl_t_frozen), dim=1)
-
-        elif freeze_h == "hs":  # Freeze short-term memory
-            logger.debug("Freezing short-term memory (hs).")
-
-            # Split into `hs_t_frozen` and `hl_t`
-            hs_t_frozen, _ = torch.split(h_tt, split_size, dim=1)
-
-            # Run the model
-            output = self.model(t0, h_tt)
-            t1_pred, t1_pred_class, h_tt = output.reg, output.cls, output.h_next
-
-            # Split the new hidden state and retain the frozen `hs_t_frozen`
-            _, hl_t_updated = torch.split(h_tt, split_size, dim=1)
-
-            # Concatenate `hs_t_frozen` with `hl_t_updated`
-            h_tt = torch.cat((hs_t_frozen, hl_t_updated), dim=1)
-
-        elif freeze_h == "all":  # Freeze both short-term and long-term memory
-            logger.debug("Freezing both hs and hl.")
-            output = self.model(t0, h_tt)
-            t1_pred, t1_pred_class = output.reg, output.cls  # Do not update h_tt
-
-        elif freeze_h == "none":  # No freezing, use normal hidden state update
-            logger.debug("Not freezing any memory.")
-            output = self.model(t0, h_tt)
-            t1_pred, t1_pred_class, h_tt = output.reg, output.cls, output.h_next
-
-        elif freeze_h == "random":  # Randomly freeze some parts
-            logger.debug("Random freezing mode activated.")
-
-            # Run model first to get new `h_tt_new`
-            output = self.model(t0, h_tt)
-            t1_pred, t1_pred_class, h_tt_new = output.reg, output.cls, output.h_next
-
-            # Vectorized Chunk Selection (ADR 028 Performance Hardening)
-            num_chunks = self._RANDOM_FREEZE_NUM_CHUNKS
-            split_size_small = num_channels // num_chunks
-            B, _, H, W = h_tt.shape
-
-            # Generate binary mask on the correct device
-            mask = (
-                torch.rand(num_chunks, device=self.device) < self._RANDOM_FREEZE_PROBABILITY
-            ).float()
-            mask_expanded = mask.view(1, num_chunks, 1, 1, 1).bool()
-
-            h_tt_reshaped = h_tt.view(B, num_chunks, split_size_small, H, W)
-            h_tt_new_reshaped = h_tt_new.view(B, num_chunks, split_size_small, H, W)
-
-            h_tt = torch.where(mask_expanded, h_tt_reshaped, h_tt_new_reshaped).view(
-                B, num_channels, H, W
-            )
-
-        else:
-            err_msg = (
-                f"Invalid freeze_h option: {freeze_h}. "
-                "Must be one of ['hl', 'hs', 'all', 'none', 'random']."
-            )
-
-            logger.error(err_msg)
-
-            raise ValueError(err_msg)
-
-        return t1_pred, t1_pred_class, h_tt
 
     def predict(
         self,
@@ -349,7 +239,13 @@ class HydraNetInference:
                 # C-113: clamp ONLY the fed-back copy to the in-domain ceiling; the
                 # emitted prediction (appended below) is never capped.
                 t0_autoreg = self._clamp_feedback(t1_pred.detach())
-                t1_pred, t1_pred_class, h_tt = self.execute_freeze_h_option(t0_autoreg, h_tt)
+                # freeze_h retired (2026-06-05): the rollout evolves the full ConvLSTM
+                # state every step (the former "none" behaviour) — the only mode that was
+                # not a train/inference mismatch, and the freeze was inert vs the C-113
+                # runaway anyway (rides the prediction→input feedback path, not the state).
+                # Durable fix: Axis-B rollout training (rollout_training_dossier, ADR-058).
+                output = self.model(t0_autoreg, h_tt)
+                t1_pred, t1_pred_class, h_tt = output.reg, output.cls, output.h_next
                 t1_pred_class = torch.sigmoid(t1_pred_class)
 
                 # C-20: Soft magnitude guard — detect gradual drift


### PR DESCRIPTION
Two commits, stacked on the C-113 working branch.

## 🅰 `696feb4` — rollout-training dossier (Axis B) + method review + balancer-sweep verdict
Designs the **durable** C-113 fix at the training-algorithm level ("train the model the way it is used"), grounded in three papers read in full: **Brandstetter** (pushforward), **Hess** (GTF), **Lamb** (Professor Forcing).
- `reports/2026-06-05_rollout_training_dossier/` — `02_design` (B1 pushforward / B2 GTF / B3 Professor Forcing + `rollout_horizon` HP + GPU-cost analysis) and `02b` expert-method-review (Hochreiter / DL-engineer / Sutton / Gneiting / Shi / Operational; 6 fixes folded in as R1–R7).
- Register: **+C-125** (rollout-procedure premises: proper-score / horizon / chaos), **+C-126** (point-stability ≠ calibration); merges M-RT5→C-113, M-RT6→C-112.
- **Balancer×seed sweep verdict:** F2 fired (`seed4_frozen → inf`) — freezing the balancer is **seed-fragile, not a robust fix**; exposure bias (C-125) is the root. C-124 stays open.

## 🅱 `4e5273a` — retire the inference-time `freeze_h` hack
The pre-registered ablation showed every `freeze_h` mode (incl. `all`) explodes identically under the runaway → the divergence rides the **prediction→input feedback path, not the recurrent state**. `freeze_h` was inert against the failure it was meant to study, while creating a train/inference mismatch.
- Removed `execute_freeze_h_option` + the required `freeze_h` config field; the rollout now always evolves the full ConvLSTM state (former `"none"` behaviour).
- ADR-027 retirement note; CIC field count 71→70; 5 capability tests → one reintroduction guard.

### Verification
- **Characterization gate PASSED (M-RT5):** `pink_pirate` (healthy) on the freeze_h-removed path reproduces its reference step-wise CRPS to ~3 d.p. — lr_sb **0.133** / lr_ns **0.031** / lr_os **0.051**. GPU-enforced eval (on-GPU verified, no CPU fallback).
- ruff ✓ · 699 passed / 7 skipped / 10 xfailed ✓ · `validate_docs.sh` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)