### PR TITLE
Rollout-training 05 pre-analysis plan (B1 MVP) — resolves falsify P2/P4

### DIFF
--- a/docs/CICs/HydraNetConfig.md
+++ b/docs/CICs/HydraNetConfig.md
@@ -23,7 +23,7 @@ The `HydraNetConfig` is the **Schema** of the HydraNet pipeline. Its primary pur
 
 ## 3. Responsibilities and Guarantees
 
-- **Field Validation:** Guarantees that all 70 fields are type-checked and constraint-validated (e.g., `dropout_rate` in [0.0, 1.0], `input_channels >= 1`). *(`freeze_h` retired 2026-06-05 — see ADR-027 update.)*
+- **Field Validation:** Guarantees that all 71 fields are type-checked and constraint-validated (e.g., `dropout_rate` in [0.0, 1.0], `input_channels >= 1`, `rollout_horizon >= 1`). *(`freeze_h` retired 2026-06-05; `rollout_horizon` added 2026-06-06 — Axis B / #78.)*
 - **Feedback Clamp (C-113):** `feedback_clamp_log1p` is an optional per-target log1p ceiling (`list[float] | None`, default `None`) bounding only the autoregressive feedback input, never an emitted prediction. See `reports/preanalysis_feedback_clamp.md`.
 - **Balancer Freeze (C-113 bisect):** `freeze_multitask_balancer` (`bool`, default `False`) excludes the MultiTaskLoss `log_vars` from the optimizer (pre-C-111 equal-weighting regime). See `reports/preanalysis_balancer_bisect.md`.
 - **Checksum Laws (ADR-009):** Guarantees `input_channels == len(features)` and `time_steps == len(steps)`.

--- a/reports/2026-06-05_rollout_training_dossier/00_README.md
+++ b/reports/2026-06-05_rollout_training_dossier/00_README.md
@@ -42,11 +42,11 @@ option (Professor Forcing), all governed by one config hyperparameter,
 |---|------|------|--------|
 | 00 | `README` | spine (this file) | living |
 | 01 | `literature` | the three papers + recurrent-stability neighbours, annotated | drafted 2026-06-05 |
-| 02 | `design` | the Axis-B design + the `rollout_horizon` HP + GPU-cost analysis | drafted 2026-06-05 — **reviewed (see 02b); revisions pending** |
+| 02 | `design` | the Axis-B design + the `rollout_horizon` HP + GPU-cost analysis | drafted 2026-06-05 — **reviewed (02b); revised 2026-06-06 (R1–R7 folded, see §10)** |
 | 02b | `method_review` | expert-method-review panel verdict + methodological risks | done 2026-06-05 |
 | 03 | `harness_and_invariants` | guardrails (to build) | TODO |
 | 04 | `roadmap` | gated implementation/experiment sequence | TODO |
-| 05 | `analysis_plan` | first pre-registered experiment | TODO (after review) |
+| 05 | `analysis_plan` | first pre-registered experiment (B1 MVP, active balancer; resolves falsify P2/P4) | **seeded 2026-06-06** |
 | 06 | `glossary` | exposure bias, pushforward, GTF, α, K, zero-stability… | TODO |
 | 07 | `experiment_log` | append-only ledger | TODO |
 
@@ -81,9 +81,12 @@ option (Professor Forcing), all governed by one config hyperparameter,
 - [ ] Kill `freeze_h` (Element 1) — `freeze_h="none"`, remove the inference-time
       state-freeze; **gate behind the `rollout_horizon=1` parity guard + golden_hour
       re-eval** (Operational). Grounded in `reports/results_freezeh_ablation.md` (inert).
-- [ ] `03` harness + `05` pre-registered first experiment (B1 pushforward, K=1 default).
-- [ ] **Sequence the program after the C-111 balancer verdict closes** (don't tune
-      rollout HPs atop the unattributed acute trigger).
+- [x] `05` pre-registered first experiment (B1 pushforward MVP, **active** balancer, K=12;
+      resolves falsify P2/P4 → C-125 note / C-129). Decisions: R6 satisfied; active is the
+      primary arm; Axis B sequenced **before** ZITD.
+- [ ] `03` harness — the rollout-loss test harness (the remaining doc gate before B1 impl, #78).
+- [x] ~~Sequence after the C-111 balancer verdict closes~~ — **verdict in** (sweep: freeze
+      seed-fragile, exposure-bias is root); R6 satisfied, proceed.
 - **Strongest live dissent (D5):** fixing the point runaway may not fix — and could
   worsen (mean-hedging/blurring) — the chronic MCR/zero-rate calibration problem. Carry
   as a falsifier, not a footnote.

--- a/reports/2026-06-05_rollout_training_dossier/00_README.md
+++ b/reports/2026-06-05_rollout_training_dossier/00_README.md
@@ -44,7 +44,7 @@ option (Professor Forcing), all governed by one config hyperparameter,
 | 01 | `literature` | the three papers + recurrent-stability neighbours, annotated | drafted 2026-06-05 |
 | 02 | `design` | the Axis-B design + the `rollout_horizon` HP + GPU-cost analysis | drafted 2026-06-05 — **reviewed (02b); revised 2026-06-06 (R1–R7 folded, see §10)** |
 | 02b | `method_review` | expert-method-review panel verdict + methodological risks | done 2026-06-05 |
-| 03 | `harness_and_invariants` | guardrails (to build) | TODO |
+| 03 | `harness_and_invariants` | invariants (hard / changed / respect) + standing harness + §3 new-harness gaps + pre-flight checklist | **seeded 2026-06-06** |
 | 04 | `roadmap` | gated implementation/experiment sequence | TODO |
 | 05 | `analysis_plan` | first pre-registered experiment (B1 MVP, active balancer; resolves falsify P2/P4) | **seeded 2026-06-06** |
 | 06 | `glossary` | exposure bias, pushforward, GTF, α, K, zero-stability… | TODO |
@@ -84,7 +84,12 @@ option (Professor Forcing), all governed by one config hyperparameter,
 - [x] `05` pre-registered first experiment (B1 pushforward MVP, **active** balancer, K=12;
       resolves falsify P2/P4 → C-125 note / C-129). Decisions: R6 satisfied; active is the
       primary arm; Axis B sequenced **before** ZITD.
-- [ ] `03` harness — the rollout-loss test harness (the remaining doc gate before B1 impl, #78).
+- [x] `03` harness + pre-flight checklist — invariants, standing harness, and the §3 new-harness
+      gaps to build before B1 (the last *doc* gate).
+- [ ] **Build the §3 harness gaps (TDD)** then **B1 (#78)** — the pushforward path behind
+      `rollout_horizon` (K=1 parity), the feedback-gradient-liveness test, annealed weight +
+      uncontaminated CRPS, gradient clipping, the full-36 boundedness + calibration readouts.
+      *(Training-loop change + GPU — the real build; gated on this checklist going green.)*
 - [x] ~~Sequence after the C-111 balancer verdict closes~~ — **verdict in** (sweep: freeze
       seed-fragile, exposure-bias is root); R6 satisfied, proceed.
 - **Strongest live dissent (D5):** fixing the point runaway may not fix — and could

--- a/reports/2026-06-05_rollout_training_dossier/00_README.md
+++ b/reports/2026-06-05_rollout_training_dossier/00_README.md
@@ -86,12 +86,16 @@ option (Professor Forcing), all governed by one config hyperparameter,
       primary arm; Axis B sequenced **before** ZITD.
 - [x] `03` harness + pre-flight checklist — invariants, standing harness, and the §3 new-harness
       gaps to build before B1 (the last *doc* gate).
-- [ ] **Build the §3 harness gaps (TDD)** then **B1 (#78)** — the pushforward path behind
-      `rollout_horizon` (K=1 parity), the feedback-gradient-liveness test, annealed weight +
-      uncontaminated CRPS, gradient clipping, the full-36 boundedness + calibration readouts.
-      *(Training-loop change + GPU — the real build; gated on this checklist going green.)*
-- [x] ~~Sequence after the C-111 balancer verdict closes~~ — **verdict in** (sweep: freeze
-      seed-fragile, exposure-bias is root); R6 satisfied, proceed.
+- [ ] **Build the §3 harness gaps (TDD) → the real (c) GTF / unroll-K (#78)** — pushforward/GTF
+      behind `rollout_horizon` (K=1 parity), feedback-gradient-liveness test, annealed weight +
+      uncontaminated CRPS, gradient clipping, full-36 boundedness + calibration readouts.
+      *(Training-loop change + GPU — the durable build; gated on the checklist + the EXP-02 verdict.)*
+- [x] ~~Sequence after the C-111 balancer verdict closes~~ — **verdict in**; R6 satisfied, proceed.
+
+**Experiment track** (cheap scheduled-sampling proxy *before* the real (c) build — full log in `07`; reviews in `02c`/`02d`):
+- [x] **EXP-01** always-feed `ss_epsilon_max=1.0`: runaway **gone**, but **collapsed to 0** (bounded-but-useless — the predicted "goes bland"). Axis so far: **0.25 explode / 1.0 collapse**.
+- [ ] **EXP-02** middle ceiling `~0.5` **+ real eval**: does plain-SS have a stable-*nonzero* regime? (VoI gate, pre-registered in `07`). Rule: nonzero ∧ skill → confirm on 2nd seed; else → commit to **(c) GTF**.
+- [ ] **(c)** the durable build (GTF / unroll-K, `05`/#78) — informed by EXP-02; chair's "scheduler" instinct = GTF's α-anneal.
 - **Strongest live dissent (D5):** fixing the point runaway may not fix — and could
   worsen (mean-hedging/blurring) — the chronic MCR/zero-rate calibration problem. Carry
   as a falsifier, not a footnote.

--- a/reports/2026-06-05_rollout_training_dossier/00_README.md
+++ b/reports/2026-06-05_rollout_training_dossier/00_README.md
@@ -45,10 +45,10 @@ option (Professor Forcing), all governed by one config hyperparameter,
 | 02 | `design` | the Axis-B design + the `rollout_horizon` HP + GPU-cost analysis | drafted 2026-06-05 — **reviewed (02b); revised 2026-06-06 (R1–R7 folded, see §10)** |
 | 02b | `method_review` | expert-method-review panel verdict + methodological risks | done 2026-06-05 |
 | 03 | `harness_and_invariants` | invariants (hard / changed / respect) + standing harness + §3 new-harness gaps + pre-flight checklist | **seeded 2026-06-06** |
-| 04 | `roadmap` | gated implementation/experiment sequence | TODO |
+| 04 | `roadmap` | gated phase sequence (P0 decide → P1 harness → P2 B1 wired → P3 MVP → P4 iterate/escalate → P5 ADR-058) + dep-graph + milestones | **seeded 2026-06-06** |
 | 05 | `analysis_plan` | first pre-registered experiment (B1 MVP, active balancer; resolves falsify P2/P4) | **seeded 2026-06-06** |
-| 06 | `glossary` | exposure bias, pushforward, GTF, α, K, zero-stability… | TODO |
-| 07 | `experiment_log` | append-only ledger | TODO |
+| 06 | `glossary` | exposure bias, pushforward, GTF, α, K, zero-stability… | **seeded 2026-06-06** |
+| 07 | `experiment_log` | append-only ledger (precursors + EXP-01 planned) | **seeded (skeleton) 2026-06-06** |
 
 ## 4. Harness at a glance
 

--- a/reports/2026-06-05_rollout_training_dossier/02_design.md
+++ b/reports/2026-06-05_rollout_training_dossier/02_design.md
@@ -105,6 +105,49 @@ feedback." B3 is the maximal, distribution-matching option — kept in the catal
 not proposed first (cost + the "no benefit < 100 steps" caveat, and our window may be
 short).
 
+### 4.3 B1 relative to ADR-056 scheduled sampling — what actually changes, and the gradient contract
+
+*(Added 2026-06-06, pre-increment-2 design clarification — surfaced when implementation began.)*
+
+**The existing scheduled sampling is already a proto-pushforward.** `_process_sequence`
+(lines 191–200) with `ss_epsilon > 0` feeds `prev_pred = t1_pred.detach()` back as the
+input (Bernoulli@`ss_epsilon`) and computes the per-step loss on the prediction made
+*from that fed-back input*. Because only the **cross-step** link is detached — not the
+current step's `model(t0_input, h)` call — **the model's weights already receive gradient
+at the perturbed (own-prediction) operating point.** That is exactly Brandstetter's
+recipe ("unroll, but backprop only the last step"). So we are **not** adding gradient
+where there is none; we are **refining a term-less, Bernoulli-masked proto-pushforward.**
+
+**Therefore "feedback gradient SEVERED" (§2) is precise but easily mis-read.** What is
+severed is the **cross-step / through-time** feedback gradient (prev_pred → next input).
+The **within-step** operator gradient (fed-back input → output → loss → weights) is live
+whenever `ss_epsilon>0`. B1 does **not** restore the cross-step gradient — **B2 GTF does**
+(it un-detaches and α-bounds it). This distinction sets the test contract below.
+
+**What B1 (pushforward) changes over ADR-056:**
+1. **Always-feed (not Bernoulli):** the stability evaluation uses the model's own
+   one-step-prior prediction every step (or on an annealed schedule), not with prob
+   `ss_epsilon` — so the operator is trained at the operating point it will actually
+   occupy at inference.
+2. **An explicit, annealed `L_stability` term** (weighted, → small; CRPS uncontaminated,
+   R1) — vs SS's implicit "sometimes the input is a prediction."
+3. **K-step coverage** via `rollout_horizon` (reach the step-12 onset).
+4. Gradient stays **last-step-only** (detach across steps) — flat memory in K.
+
+**The gradient contract increment-2 tests must assert (corrected):**
+- ✅ **B1:** under `rollout_horizon>1`, `∂L_stability/∂(model params)` is **non-zero and
+  finite** — i.e. the stability term trains the weights *at the fed-back operating point*.
+  (NOT "the cross-step feedback gradient is live" — that would be testing B2.)
+- The cross-step feedback **remains detached** under B1 (assert it, to keep memory flat
+  and to keep B1 distinct from B2).
+- `rollout_horizon=1` ⇒ byte-identical to today (parity).
+
+**Decision (for the method review to contest):** B1 is the *minimal, honest refinement*
+of machinery we already ship (ADR-056), so it is the right first rung — **unless** the
+panel judges that the cross-step gradient (B2 GTF) is necessary from the outset because
+the runaway rides a *through-time* dependency that last-step-only training cannot reach.
+That is the live question for the `expert-method-review` below.
+
 ## 5. The `rollout_horizon` hyperparameter (K)
 
 A single config knob, the "look-ahead depth" the user described (n-beats-like):

--- a/reports/2026-06-05_rollout_training_dossier/02c_method_review_b1_vs_b2.md
+++ b/reports/2026-06-05_rollout_training_dossier/02c_method_review_b1_vs_b2.md
@@ -1,0 +1,66 @@
+# 02c — Expert Method Review: B1 pushforward first, or straight to B2 GTF?
+
+**Date:** 2026-06-06 · **Skill:** `expert-method-review` · **Target:** `02_design.md §4.3` · **Chair:** simon (not seated)
+**Trigger:** surfaced at the start of increment-2 implementation — ADR-056 scheduled sampling is already a proto-pushforward, so what does B1 add?
+
+---
+
+## 1. Target & decision under review
+**One question:** is **B1 pushforward** the right *first* rung of the C-113 rollout-training fix, or should we go straight to **B2 GTF**?
+
+**The decisive fact (verified this session):** scheduled sampling was **active** in the runs that exploded — `violet` config `ss_epsilon_max=0.25`, scheduled via `ss_mixer`. ADR-056 SS feeds `prev_pred.detach()` and scores the prediction-from-it ⇒ the **within-step operator gradient was already live** (last-step pushforward), at a 25% feed rate, **and the post-C-111 runaway happened anyway.** So B1 ("always-feed + an annealed stability term, gradient still last-step-only") is a *stronger dose of a mechanism that already failed at 25%*, not a new capability. **B2 GTF** is the genuinely new lever: un-detach + α-bound the **cross-step / through-time** gradient (scales every Jacobian by `(1−α)`).
+
+**DGP/diagnosis to respect:** the io-gain probe found the free-running operator's **Jacobian gain `‖J‖₂ > 1`** with an **out-of-range attractor** the training trajectory never visits. That is a *dynamics* (product-of-Jacobians) property, not just an operating-point-distribution property.
+
+## 2. Panel
+| Seat | Why | Side |
+|---|---|---|
+| **Hochreiter** | through-time gradient / product-of-Jacobians; SS-failed is his kind of tell | B2 / dynamics |
+| **DL-engineer** | cost/diff/memory — B1 is nearly free | B1-as-cheap-falsification |
+| **Sutton** | bitter lesson; if the simple general method (train-on-own-output) failed, question the framing | reframe (maybe it's the link) |
+| **Shi** | ConvLSTM nowcasting practice — how is multi-step rollout actually stabilised there | B2 (unrolled training) |
+
+## 3. Library grounding
+**Held & load-bearing:** `Brandstetter2022` (pushforward — note it trains at `A_# p_k`, *near the data*), `hess23a` (GTF — bounds the **Jacobian product** globally via `(1−α)`, Eq. 8), `NIPS-2015 scheduled-sampling` (the proto-pushforward we already ship), `Pascanu2013` (exploding/vanishing — clipping; the product-of-Jacobians), `MillerHardt2019` (stable RNN ≈ feed-forward — the expressiveness cost of contractivity), `Miyato2018` (spectral norm — a *direct* operator-norm bound), `Erichson2021`/`Chang2019`/`Arjovsky2016` (Lipschitz/antisymmetric/unitary — the architectural-stability family). **Gap → fetch:** `Mikhaeil2022` (chaotic-DS ill-posedness — load-bearing for whether GTF's α-bound is *needed* vs over-imported).
+
+## 4. Independent critiques
+
+### Hochreiter — *the product-of-Jacobians realist*
+- **SS-failed is the diagnostic.** Last-step training optimises the one-step map at *visited* points; it does **not** control the product `∏ Jₖ` that governs multi-step divergence (Pascanu 2013). The runaway is that product growing — exactly what last-step (B1/SS) leaves untouched. **GTF's `(1−α)` scaling tames the product directly** (Hess Eq. 8). → **B2 is the on-target lever; B1 is more of the thing that already failed.**
+- **But B2 reopens the wound:** un-detaching restores exploding/vanishing gradients — so α-bounding **and** gradient clipping (Pascanu) are mandatory, not optional.
+- **The gain>1 is spectral** → a **spectral-norm / Lipschitz** constraint on the input→output operator (Miyato 2018 / Erichson 2021) is a *direct* complement the B1/B2/B3 ladder omits. Combine with training-level (belt-and-suspenders), since Hess argues architecture-alone is insufficient for chaotic targets.
+
+### DL-engineer — *the throughput pragmatist*
+- **B1 is nearly free** — it's turning up an existing knob (`ss_epsilon`→always) + adding a weighted term; flat memory in K. B2 is O(K) BPTT memory + α tuning + clipping.
+- **So run B1 as a one-shot falsification, not a campaign.** Given SS@0.25 failed, the honest prior is low — but the cost to *learn* is one cheap run + the 30 s io-gain readout. If always-feed+term doesn't move the attractor in one run → escalate to B2 immediately. **Don't sink effort into B1; sink it into the B1→B2 gate.**
+- Wants the dose quantified: SS was 25% feed; B1 is 100% + a term — is *that* delta expected to matter? Pre-register the expectation.
+
+### Sutton — *the bitter-lesson contrarian*
+- **The simple general method already ran and failed.** Training on the model's own outputs (SS) is the general move; at 25% it didn't prevent the runaway. "Add α-machinery" (B2) or "more SS knobs" (B1) are both *added structure* on a signal that didn't bite.
+- **Question the framing:** if the dynamics diverge to an **out-of-range** attractor, maybe the problem is the **unbounded `expm1` output representation**, not the training signal. The **ZITD softplus link** (the *other* dossier) makes divergence *linear*, not exponential — a structural fix that doesn't need rollout-gradient cleverness. → this **pressure-tests the P4/C-129 "Axis B first" decision**: maybe ZITD (the link) should lead.
+- Minimal-move alternative he'd still try before B2's α: **longer training windows / more compute** through the rollout.
+
+### Shi — *the ConvLSTM nowcasting author*
+- **Nowcasting stabilises multi-step rollout by unrolling the forecaster and training through it** (BPTT through the rollout) — i.e. **cross-step gradient (B2-flavoured)**, *not* last-step-only. The field precedent is against B1-as-sufficient.
+- Practical: use **truncated BPTT** (K window) + clipping — exactly B2-with-TBPTT. This is well-trodden for spatiotemporal ConvLSTM.
+- Reiterates the **blurring** caveat (multi-step optimisation → mean-hedging): applies to B1 and B2 alike; keep the calibration/sharpness readout (C-126).
+
+## 5. Key disagreements
+- **B1-first vs B2-first.** DL-engineer: B1 is so cheap, run it as a falsification gate. Hochreiter + Shi: the evidence (SS-failed + gain>1 product-of-Jacobians + nowcasting precedent) says the cross-step gradient (B2) is the actual missing ingredient — B1 is predicted to fail. *Merit:* both right — B1 is cheap *to falsify*, but its *success* prior is genuinely low; the resolution is to run it **as an explicitly-low-prior one-shot gate**, not as "the fix."
+- **Training-signal vs representation (the deepest one).** Sutton: maybe neither B1 nor B2 is the fix — the unbounded `expm1` link is, and the **ZITD softplus head should lead** (reopens P4/C-129). vs the rest: rollout training and the link are complementary; fix the dynamics. *Merit:* Sutton's point is strong *because* the attractor is out-of-range (a link that makes divergence linear would defang it) — this is a real challenge to "Axis B first."
+- **Architecture lever omitted.** Hochreiter: spectral-norm/Lipschitz directly bounds the diagnosed `‖J‖₂>1` and belongs in the ladder; the design treats it only as a passing mention in §3.
+
+## 6. Synthesis & recommendation
+1. **Reframe B1 (don't cancel it).** The SS-already-failed fact lowers B1's success prior sharply. `05`'s `F1 → B2` escalation is therefore the **expected path, not a fallback** — make that explicit: B1 is a **one-shot, low-prior falsification gate** (cheap: always-feed+term, one run + io-gain readout). If it doesn't move the attractor → B2 immediately. *Pre-register the low prior* so a B1 failure isn't a surprise or a sunk cost.
+2. **Promote B2 GTF (+ clipping) to the likely-real fix** — and treat **spectral-norm/Lipschitz** (Miyato/Erichson) as a **peer lever / complement**, since the diagnosis is literally operator gain >1. Add it to the B1/B2/B3 ladder rather than a footnote.
+3. **Re-open the P4/C-129 sequencing as a genuine question, not a settled "Axis B first."** Sutton's link argument + the out-of-range-attractor diagnosis are strong enough that "ZITD softplus first" deserves an honest comparison. *Strongest dissent to keep live.*
+4. **Fetch `Mikhaeil2022`** before committing to B2's α-bound *as theory* (vs heuristic).
+
+**Strongest dissent (carry live):** *the runaway may be an output-representation problem (unbounded `expm1`), in which case the ZITD softplus link — not rollout-gradient training — is the fix, and "Axis B first" (C-129) is wrong.*
+
+## 7. Methodological risks (register-compatible — for `register-risk`)
+| ID | Tier | Trigger | Location | Narrative |
+|----|------|---------|----------|-----------|
+| **RT-B1prior** | 3 | Running/scaling B1 as "the fix" without pre-registering that SS (proto-pushforward) already failed at ε=0.25 ⇒ B1's success prior is low | `02_design §4.3`, `05` | Last-step operator training already ran (SS) and didn't prevent the runaway; B1 is a stronger dose of the same. Treat as a one-shot low-prior falsification gate with automatic B2 escalation, not a campaign. |
+| **RT-spectral** | 3 | Building the B1/B2/B3 ladder without the direct operator-norm lever | `02_design §4.2`, §3 | The diagnosis is `‖J‖₂>1`; spectral-norm/Lipschitz (Miyato/Erichson) bounds it directly and composes with B1/B2 — it's omitted from the ladder. |
+| **RT-P4reopen** | 3 | Treating "Axis B first" (C-129) as settled when the out-of-range attractor implies the unbounded `expm1` link may be the real cause | `02_design §4.3`, C-129 | The ZITD softplus link makes divergence linear-not-exponential — a structural cure that may dominate rollout-gradient training. The P4 sequencing should be an explicit comparison, not an assumption. |

--- a/reports/2026-06-05_rollout_training_dossier/02d_method_review_next_experiment.md
+++ b/reports/2026-06-05_rollout_training_dossier/02d_method_review_next_experiment.md
@@ -1,0 +1,61 @@
+# 02d — Expert Method Review: what's the next experiment? (value-of-information)
+
+**Date:** 2026-06-07 · **Skill:** `expert-method-review` · **Chair:** simon (Bayesian; not seated)
+**Trigger:** two data points in hand — SS-ceiling **0.25 → explode**, **1.0 → collapse-to-zero**. Which next step has the highest information-per-cost: (a) confirm-collapse eval, (b) an intermediate-ceiling run, (c) build the unroll-K/GTF fix?
+
+---
+
+## 1. Decision under review & the DGP
+Pure **experiment-design / VoI** question. Evidence: along the *scheduled-sampling ceiling* axis (the dial already ramps low→ceiling over training), **0.25 explodes** (too little own-prediction practice → its feedback amplifies) and **1.0 collapses to 0** (too much → it learns the trivial zero fixed point). DGP that makes this sharp: **~95% zero cells** — so "predict zero everywhere" is a strong degenerate attractor the loss happily rewards. The question: is there a *stable-nonzero* regime in between, and is finding out worth ~80 min?
+
+## 2. Panel
+| Seat | Why | Fault line |
+|---|---|---|
+| **Gelman** (Bayesian workflow / VoI) | "which experiment would change the decision?" — the chair's tribe | run-the-cheap-bracket vs not |
+| **Sutton** (bitter lesson) | don't burn runs sweeping a crude knob; build the general method | (b) vs (c) |
+| **DL-engineer** | ~80 min/run budget; marginal-run worth | cost |
+| **Hochreiter** (dynamics) | does explode∧collapse already prove per-step SS has no good regime? | knife-edge vs Goldilocks |
+
+## 3. Library grounding
+**Held:** `Brandstetter2022` (pushforward = the unroll-K of (c); trains near the data manifold), `hess23a` (GTF — the **α-anneal scheduler** the chair is intuiting: interpolate the fed-back *state* + **bound the gradient**, a *different and more principled* scheduler than an SS Bernoulli ceiling), `NIPS-2015 scheduled-sampling` (the dial we're sweeping). **Gaps → fetch:** `Huszár2015` (SS is a **biased estimator** — known secondhand via Lamb 2016 / Professor-Forcing, which we hold; load-bearing here), `Mikhaeil2022` (chaotic-DS ill-posedness).
+
+## 4. Independent critiques
+
+### Gelman — *value of information*
+- **(a) is low-VoI: skip it as a standalone.** It would mostly confirm what we already believe (flatline-to-0, qualitatively unlike healthy pink) and **doesn't change the decision** — we won't ship the 1.0 model regardless. Don't run an experiment whose every outcome leaves the decision unchanged.
+- **(b) is the high-VoI move *because* the panel can't resolve it from theory.** We have two endpoints; the middle is genuinely unknown (Goldilocks or knife-edge?). One ~80-min run **resolves that uncertainty cheaply** — and either *cheaply solves it* or *kills the plain-SS family with evidence*. That's textbook "run the experiment that splits your hypotheses."
+- **But fold the real eval into (b)'s readout.** Don't judge (b) on the synthetic probe alone (same gap that makes (a) tempting). One retrain → read **both** `diagnose_io_gain` (stability) **and** a real eval (skill/collapse). That single run answers explode-vs-collapse-vs-Goldilocks **and** probe-vs-real in one shot — subsuming (a) into (b).
+
+### Sutton — *bitter lesson*
+- **The SS axis is a crude knob; stop sampling it.** We already know own-prediction training is the lever and that plain per-step SS brackets explode/collapse. Sweeping its ceiling is tuning a weak method. **Build the general one (c)** — unroll-K with controlled depth (and let K/strategy be learned, per the chair's own brainstorm).
+- **80 min on (b) is 80 min not on (c).** If the durable answer is the structured lever, the bracket-point is a detour.
+- Concedes: if (b) is *truly* near-free and could cheaply settle it, it's not unreasonable — but don't let a Goldilocks-SS-win **distract** from building the real thing, because (see Huszár) it'd be a biased patch.
+
+### DL-engineer — *cost*
+- **(b) is cheap: zero code, one config value, ~80 min** — and the harness (GPU-enforced driver, diagnose_io_gain, baselines) already exists. (c) is **days** (training-loop code + the K-strategy + tests + runs).
+- So **sequence by cost**: the ~free bracket-point first; commit the expensive (c) build *after* it tells us whether plain-SS is dead. Cheapest decisive evidence before the costly build.
+
+### Hochreiter — *dynamics / knife-edge*
+- **explode@0.25 + collapse@1.0 likely brackets a *knife-edge*, not a plateau.** With ~95% zeros, strong own-feedback drives the **zero fixed point**; weak own-feedback leaves the operator gain >1 → explode. A stable-**nonzero** attractor may be measure-zero on this axis — so **(b) probably fails**, and its information is "confirm no good SS regime."
+- **The real lever isn't the operating-point distribution (what SS/pushforward shift) — it's the Jacobian product.** GTF's `(1−α)` scaling bounds *that* (Hess Eq. 8); a ceiling sweep doesn't touch it. So the chair's "scheduler" instinct is right but its principled form is **GTF (c/B2)**, not an SS ceiling.
+- **Huszár:** SS is biased — *no* ceiling is guaranteed to recover the right model. Another reason (b)'s upside is capped.
+
+## 5. Key disagreements
+- **The crux — Goldilocks vs knife-edge:** Gelman/DL-engineer say *we cannot know without the cheap run* (→ run (b)); Hochreiter says *theory + the bracket + Huszár already predict no stable-nonzero SS regime* (→ (b) is low-information, go (c)). **Merit:** Hochreiter is probably right on the prior, **but a Bayesian doesn't skip a near-free experiment that would update a genuinely uncertain belief** — and if Hochreiter is right, (b) *converts his prediction into evidence*, which is what lets you commit to (c) without second-guessing.
+- **(b) vs (c) (Sutton vs Gelman):** parsimony/momentum (build the real method) vs evidence-discipline (one cheap datum first). The 80-min cost is small enough that this is close.
+- **Everyone agrees:** skip standalone (a); never declare a run "works" on the synthetic probe alone (pair with a real eval) — that's the C-126/C-128 calibration discipline.
+
+## 6. Synthesis & recommendation
+**Run exactly one more cheap experiment, designed to be decisive, then commit to (c) regardless.**
+1. **(b′) — one retrain at an intermediate ceiling (~0.5), read BOTH `diagnose_io_gain` *and* a real eval** (stability + skill/collapse in one ~80-min shot; this *subsumes* (a)). Pre-register the split: *stable & nonzero & nontrivial skill* → plain-SS has a regime (cheap win, surprising); *explode, collapse, or stable-but-zero-skill* → **plain SS has no good regime — confirmed, not assumed.**
+2. **Then build (c) — the controlled unroll-K / GTF** — *informed* by (b′). Note the chair's "start-low scheduler" instinct is **GTF's α-anneal**, so (c) should be **B2-flavoured** (bounded cross-step gradient), not just a deeper pushforward.
+3. **Skip standalone (a)** — its VoI is folded into (b′)'s real eval.
+
+**Strongest dissent to keep live (Sutton + Hochreiter):** the bracket + Huszár's bias result may already be enough — (b′) risks being an 80-min confirmation of a foregone conclusion, and the honest VoI may be ~zero if your prior on "no SS regime" is already high. *If the chair's posterior is already confident plain-SS is dead, skip (b′) and go straight to (c).* The decision genuinely turns on **how uncertain you actually are** about the knife-edge — which only you can price.
+
+## 7. Methodological risks (register-compatible)
+| ID | Tier | Trigger | Location | Narrative |
+|----|------|---------|----------|-----------|
+| **RT-knifeedge** | 3 | Reading a "stable" (b′) result off the synthetic probe and concluding plain-SS works | `diagnose_io_gain`; `05` | explode@0.25 ∧ collapse@1.0 may bracket a knife-edge with no stable-*nonzero* regime; a middle ceiling can look "in-range" on the synthetic probe while being zero-skill (the 1.0 collapse already reads "healthy (in-range)" at 0.00). Always pair (b′) with a real eval (skill/MCR), never the probe alone. Ties C-126/C-128. |
+| **RT-VoI** | 4 | Running confirmatory-only experiments (e.g. standalone (a)) that can't change the decision | dossier `07` | Discipline: run the experiment that *splits hypotheses*, not the one that *confirms the expected*. (a) is low-VoI; (b′) is only worth it if the knife-edge uncertainty is genuinely live. |
+| **RT-biasedSS** | 3 | Committing to *any* plain-SS ceiling as the durable fix | `02_design §4.3`, `05` | Huszár 2015: scheduled sampling is a biased estimator — no ceiling is guaranteed to recover the true model. Treat (b′) as a *gate*, not a candidate endpoint; the durable fix is the (c) family (GTF's α-anneal is the principled scheduler the chair is intuiting). Fetch Huszár2015 + Mikhaeil2022. |

--- a/reports/2026-06-05_rollout_training_dossier/03_harness_and_invariants.md
+++ b/reports/2026-06-05_rollout_training_dossier/03_harness_and_invariants.md
@@ -1,0 +1,83 @@
+# 03 — Harness & Invariants (what must be in place before B1 runs)
+
+**Date:** 2026-06-06 · **Status:** seeded · **Dossier:** [00_README](00_README.md) · **Design:** [02_design](02_design.md) · **Plan:** [05_analysis_plan](05_analysis_plan.md)
+
+The safety scaffolding for the rollout-training program: what must **never** break, what B1 **intends** to change (and how to change it safely), the harness we run experiments through (most already built this session), and the pre-flight gate before any B1 training run. This is the **last doc gate** before implementing B1 (#78).
+
+---
+
+## 1. Invariants — three kinds
+
+### 1a. HARD invariants — never break (any experiment that violates one is invalid)
+
+| Invariant | Source | Why it holds for B1 |
+|-----------|--------|----------------------|
+| **`rollout_horizon=1` parity** | this program (`02 §8`) | B1 ships behind `rollout_horizon` (default 1). At K=1 the training path is **byte-identical** to today's one-step path — zero-regression proof, like `feedback_clamp`/`freeze_multitask_balancer`. |
+| **Proper score stays the headline** | Gneiting (R1) | CRPS is the predictive metric; the pushforward/GTF **stability term is a weighted, annealed regulariser**, never a replacement for the score. Headline CRPS is reported **uncontaminated**. |
+| **No output capping** | ADR-003 / ADR-028 §3 | Stability comes from *training dynamics*, not magnitude clamps. A bounded rollout that only looks bounded because something was clamped doesn't count. |
+| **Train-only forcing** | `02 §8` | Pushforward / α affect **training only**; inference stays unchanged free-running — so `diagnose_io_gain` remains a valid before/after probe. |
+| **C-121 guard stays green** | #76 | The runaway-detection guard (`test_rollout_stability_guard.py`) must pass; no B1 retrain may regress the detector. |
+| **Fail-loud + reproducibility + full suite green** | ADR-003 / ReproducibilityGate (C-42) / ADR-005 | Seed-locked, deterministic, TDD; the suite + register-integrity stay green before any run. |
+
+### 1b. Invariants B1 DELIBERATELY changes (carefully, behind the flag)
+
+| Current behavior | Source | What B1 changes it to | Care required |
+|------------------|--------|------------------------|---------------|
+| **Prediction→input feedback gradient is SEVERED** | `training_engine.py:200` (`prev_pred = t1_pred.detach()`) | **Bounded gradient flows** through the fed-back operator — pushforward backprops the *last* unroll step (flat memory); GTF (fallback) soft-mixes + α-bounds. | Gradient **clipping** (R7); detach across steps for B1 (flat memory); annealed stability weight (R1). This is the whole point — the operator the runaway rides finally gets training signal. |
+| **One-step-ahead objective** | `training_engine._process_sequence` | **+ a K-step rollout stability term** (`L_stability`, pushforward) | Annealed/small weight; CRPS uncontaminated (R1). |
+| **Trained horizon = 1 step** | the loss loop | **K-step rollout** (`rollout_horizon=12` candidate) | K must reach the blow-up onset (~step 12); the **readout certifies the full 36 steps**, not just ≤K (R2 / M-RT2). |
+
+### 1c. Constraints to respect *while* changing (don't break in passing)
+
+- **ConvLSTM hidden-state BPTT already flows** (gradient through `h` across the window). B1 adds the *feedback-path* gradient **on top** — do not break the existing `h` BPTT.
+- **`ModelOutput` contract** (`reg`/`cls`/`h_next`) — unchanged.
+- **36-step free-running inference** — unchanged (train-only forcing).
+- **The C-111 active balancer** — B1's primary arm trains *under* it (`05 §0.1`); the balancer interaction is the experiment's subject (Q4), not a thing to silence.
+- **`_df`/`_pf` parity, curriculum sampling (ADR-011/012), eval-comparability** — unchanged.
+
+## 2. The standing harness (already built — reuse, don't reinvent)
+
+| Mechanism | Where | Use for B1 |
+|-----------|-------|------------|
+| **C-121 runaway guard** | `views_hydranet/utils/rollout_diagnostics.py` (`free_running_attractor`, `is_out_of_range`) + `tests/test_rollout_stability_guard.py` | The boundedness regression guard; the shared helper is the readout primitive. |
+| **Fast retrain-free readout** | `scripts/diagnose_io_gain.py` (now consumes the helper) | Probe a fresh B1 artifact's free-running attractor (~30 s) before a ~40-min eval. |
+| **Default-off feature flags** | `config_initializer.py` (`feedback_clamp_log1p`, `freeze_multitask_balancer`) | Add `rollout_horizon` (default 1 = parity) the same way. |
+| **Reproducibility & run discipline** | ReproducibilityGate; conda `views-hydranet-env`; one model/GPU; n ≤ 64; background+notify; timestamped artifacts | All B1 runs. |
+| **GPU-enforced driver + ledger** | `views-models/scripts/run_*.sh` (CUDA pre-flight + on-GPU PID verify, `trap`-restore, no `set -e`) + `logs/*_RESULTS.txt` | B1 retrain gets a driver + an `07_experiment_log` entry. |
+| **Evaluation comparability** | baselines `…233938` (active exploder, stability baseline) + `…051634` (frozen healthy, calibration ref) + `s0_baseline_metrics.md`; CRPS is *proper* | Score B1 against these on identical metrics. |
+| **Negative-result discipline** | `reports/postmortem_*.md` | Falsifications recorded honestly; no ad hoc rescue. |
+
+## 3. New harness B1 REQUIRES (gaps to build first — TDD, before any retrain)
+
+1. **The pushforward training path behind `rollout_horizon`** + a **parity test**: with `rollout_horizon=1`, `_process_sequence` is byte-identical to today (zero-regression proof). **Blocker.**
+2. **Feedback-gradient-liveness test (the crown-jewel test):** under B1 (K>1), assert the gradient through the fed-back operator is **non-zero and finite** — i.e. B1 actually trains the operator that is currently severed (`training_engine.py:200`). This is the test that proves B1 does what it claims.
+3. **Annealed stability-weight + uncontaminated CRPS (R1):** the `L_stability` weight anneals (→ small); a test that the **headline CRPS is computed without the stability term** so the proper score isn't biased.
+4. **Gradient clipping (R7):** applied on the B1 path; a test it's active.
+5. **Full-36-step boundedness readout (R2 / M-RT2):** extend the guard / `diagnose_io_gain` to certify **all 36** steps (not just ≤K); ideally a **real-artifact** boundedness check (the remaining C-121 layer) on the produced B1 `.pt`.
+6. **Calibration readout (F2 / C-126):** PIT / coverage (PICP) / MCR / **zero-rate + sharpness** wired into the B1 eval — to catch "bounded but mean-hedged/blurred", not infer it from CRPS.
+7. **K=12 peak-memory measurement (R4):** measure activation memory at K=12, real batch, 32×32 before committing; `torch.utils.checkpoint` is the plan if it OOMs (only relevant if B2/BPTT is reached — B1 is flat in K).
+
+## 4. Experiment protocol & decision gates
+
+- **One variable:** `rollout_horizon` (the pushforward term) on the active-balancer baseline — never B1 + another change at once.
+- **Pre-register, then run:** `05_analysis_plan` is committed *before* execution (done). Acceptance + kill conditions are its falsifiers.
+- **Cheap readout before expensive:** `diagnose_io_gain` (attractor in-range across 36?) → only then a full `--evaluate`.
+- **Falsifier honesty:** a pre-registered falsifier that fires kills the hypothesis; postmortem it, don't rescue (esp. F2 — don't rationalise a calibration regression).
+- **GPU discipline:** one model; n ≤ 64; background+notify; `trap`-restore configs; preserve timestamped artifacts.
+- **Magnitude-neutral by construction:** stability must come from the *training objective*, not a clamp.
+
+## 5. Pre-flight checklist (must be green before the FIRST B1 training run)
+
+- [ ] **B1 pushforward path behind `rollout_horizon`; parity at K=1 byte-identical (§3.1)** — *blocker*.
+- [ ] Feedback-gradient-liveness test green (§3.2) — the severed gradient is live+finite under K>1.
+- [ ] Annealed stability weight; headline CRPS uncontaminated (§3.3 / R1).
+- [ ] Gradient clipping applied (§3.4 / R7).
+- [ ] C-121 guard green (it is); full-36-step boundedness readout wired (§3.5 / R2).
+- [ ] Calibration readout (PIT/coverage/MCR/zero-rate) wired into the B1 eval (§3.6 / F2 / C-126).
+- [ ] K=12 peak memory measured (§3.7 / R4).
+- [ ] Full suite green; ruff clean; register integrity green.
+- [ ] `05_analysis_plan` pre-registered (done); baselines present (`…233938`, `…051634`).
+- [ ] GPU up (CUDA pre-flight, C-115); GPU-enforced driver ready.
+- [ ] Risk entries current: C-125 (premises), C-126 (calibration), C-129 (ZITD coordination).
+
+> Reassurance: §2 already exists (the C-121 guard, `diagnose_io_gain`, the flag pattern, the GPU driver, the baselines). The genuinely new build is §3.1–3.3 (the pushforward path + the parity & gradient-liveness tests + the annealed-weight/uncontaminated-CRPS discipline) and §3.6 (the calibration readout). That is the real "before you experiment" work — to be sequenced in `04_roadmap`.

--- a/reports/2026-06-05_rollout_training_dossier/04_roadmap.md
+++ b/reports/2026-06-05_rollout_training_dossier/04_roadmap.md
@@ -1,0 +1,60 @@
+# 04 — Roadmap (implementation + experiment sequencing)
+
+**Date:** 2026-06-06 · **Status:** seeded · **Dossier:** [00_README](00_README.md)
+**Depends on:** [02_design](02_design.md) (B1 pushforward), [03_harness_and_invariants](03_harness_and_invariants.md) (the gates), [05_analysis_plan](05_analysis_plan.md) (the pre-registered MVP).
+
+Turns the design into an **ordered, gated** build. Sequencing principles (`03 §4`): **one variable at a time**; **cheapest informative experiment first**; **pre-register before running** (`05`); each step gates the next (tests → fast readout → eval). Nothing trains until the harness pre-flight (`03 §5`) is green.
+
+---
+
+## 1. Phases
+
+| Phase | Goal | Key steps | Exit gate | Depends on |
+|------:|------|-----------|-----------|-----------|
+| **P0 — Decide** | settle the B1 knobs | confirm **K=12**; the stability-term form (pushforward: feed the model's own one-step-prior prediction) + its **annealing schedule**; the gradient-clip norm; the feedback space (log1p) | knobs recorded (here + `05`) | — |
+| **P1 — Harness build (no model, no training)** | the `03 §3` gaps, TDD | (a) pushforward path behind `rollout_horizon` + **parity test** (K=1 byte-identical); (b) **feedback-gradient-liveness test**; (c) annealed-weight + **uncontaminated-CRPS** check; (d) gradient clipping; (e) full-36 boundedness readout; (f) calibration readout (PIT/coverage/MCR/zero-rate) | `03 §5` pre-flight blockers green; full suite + ruff green | P0 |
+| **P2 — B1 wired (behind the flag)** | training can run the rollout objective; baseline untouched | wire the pushforward `L_stability` into `training_engine._process_sequence` behind `rollout_horizon` (default 1) | **parity gate**: K=1 byte-identical to today; suite green | P1 |
+| **P3 — First experiment (MVP)** | does B1 bound the runaway *without* breaking calibration? | train **violet/seed-42, ACTIVE balancer**, `rollout_horizon=12` (per `05 §0.1`); fast readout first | `diagnose_io_gain` attractor **in-range across all 36** (vs the `…233938` exploder), then eval: CRPS / MCR / calibration vs `…051634` (pre-registered in `05`) | P2 |
+| **P4 — Iterate / escalate** | reach a verdict | per `05` decision rules: **F1 fires → B2 GTF** (un-detach, soft-mix, α-bound, clip); **F2 fires → ZITD layering** (C-129); vary K; **multi-seed** confirm (C-112) | each step pre-registered; logged in `07` | P3 |
+| **P5 — Decide & graduate** | commit or fall back | if B1 wins on active: **ADR-058** (`docs/ADRs/proposed/`) + **resolves C-124** + roll to golden_hour; if not: postmortem → B2 GTF or the ZITD layer | ADR proposed *or* documented negative result; dossier archived | P4 |
+
+## 2. Dependency graph
+
+```
+[C-121 guard #76 — DONE] ─┐
+P0 decide ─▶ P1 harness build (TDD: parity · grad-liveness · CRPS-quarantine · clip · 36-readout · calibration)
+                          └─▶ P2 B1 wired (flag, K=1 parity) ─▶ P3 MVP (violet/42, ACTIVE, K=12)
+                                                                      │
+                                                                      ├─▶ P4  F1→B2 GTF · F2→ZITD layer · vary K · multi-seed
+                                                                      └─▶ P5  win → ADR-058 (+resolve C-124) · else → postmortem → B2/ZITD
+ZITD dossier (C-129) ───────────────────────────────────────────────────▶ layered AFTER Axis B (P4/F2), not concurrent
+```
+
+## 3. The first experiment (MVP) — why this shape
+Smallest change that tests the core claim, per `05`. **One model** (violet/seed-42, the clean exploder), **active balancer** (the production setting + the thing that explodes — so bounding it is the real win and **resolves C-124**), **K=12** (reaches the step-12 onset), **pushforward** (flat memory, the cheap B1 before the heavier B2 GTF). Readout is the **retrain-free `diagnose_io_gain`** first (≈30 s: in-range across 36?), *then* a full eval for CRPS/MCR/**calibration** (the F2/C-126 guard). Falsifiers pre-registered in `05 §4`.
+
+## 4. Decision points (the open choices)
+
+| Choice | First cut | Decide at | Note |
+|--------|-----------|-----------|------|
+| `rollout_horizon` K | **12** | P0→P4 | reaches the blow-up onset; raise toward 36 if F3 (tail divergence) fires |
+| stability mechanism | **B1 pushforward** (detach across steps, backprop last) | P3→P4 | **B2 GTF** is the fallback if F1 fires (`02 §7.4`) |
+| stability-term weight | **annealed, small** | P0/P1 | R1 — CRPS stays the uncontaminated headline |
+| balancer arm | **active (primary)** | P3 (`05 §0.1`) | frozen = control; R6 satisfied |
+| feedback space | **log1p** (where `‖J‖₂>1` was measured) | P1 | the interpolation/perturbation lives here |
+| rollout × ZITD | **Axis B first** | P4/F2 (C-129) | ZITD softplus head layered only if calibration still needs it |
+
+## 5. Relationship to other work
+- **The C-121 guard (#76, DONE):** the prerequisite — already merged; P1 extends it to the full-36 readout.
+- **The C-111 balancer (verdict in):** R6 satisfied; the **active** arm doubles as the C-124 resolution test.
+- **ZITD dossier (C-129):** sequenced **after** Axis B (P4/F2 layering), not concurrent — both touch `training_engine` + the feedback.
+- **B2 GTF / Professor Forcing (`02 §4.2`):** the escalation ladder if pushforward under-delivers.
+
+## 6. Milestones / definition of done
+- **M1 (P1):** `03 §3` harness gaps built + tests green — *the pre-flight blockers cleared*.
+- **M2 (P2):** B1 wired behind `rollout_horizon`; **baseline byte-identical with K=1**; suite green.
+- **M3 (P3):** violet/42 active + B1 trained; `diagnose_io_gain` in-range across 36; first CRPS/MCR/calibration vs baselines in `07`.
+- **M4 (P4):** verdict path taken (B1 holds · or → B2 GTF · or → ZITD layer); multi-seed confirm.
+- **M5 (P5):** ADR-058 proposed (adopt, + C-124 resolved) **or** postmortem (fall back) — dossier archived.
+
+> Cost note: **P0–P2 are CPU/test work (no GPU)** — the real "before you experiment" build. The first GPU cost is **P3** (one ~80-min violet train + 30 s readout + one ~40-min eval). P4 ablations are the main GPU spend — one model at a time, n ≤ 64, pre-registered, GPU-enforced driver (`03 §4`).

--- a/reports/2026-06-05_rollout_training_dossier/05_analysis_plan.md
+++ b/reports/2026-06-05_rollout_training_dossier/05_analysis_plan.md
@@ -1,0 +1,69 @@
+# 05 — Analysis Plan: the first rollout-training experiment (B1 pushforward MVP)
+
+**Date:** 2026-06-06 (pre-registered *before* B1 is built) · **Status:** seeded
+**Dossier:** [00_README](00_README.md) · **Design:** [02_design](02_design.md) (R1–R7 folded) · **Review:** [02b_method_review](02b_method_review.md)
+**Gated on:** the C-113 regression guard (#76, **DONE**) + `03_harness_and_invariants` (the rollout-loss test harness, TODO) + GPU.
+
+Pre-registers the **smallest unambiguous test** of training-through-the-rollout, and **resolves the two open planning gaps** the `/falsify` audit found (RT-P2 balancer/R6 → C-125; RT-P4 rollout×ZITD → C-129). Structure mirrors the dossier convention (freeze_h, feedback-clamp, balancer-bisect, ZITD `05`).
+
+---
+
+## 0. Two decisions this plan settles (falsify RT-P2 / RT-P4)
+
+### 0.1 P2 — balancer config + the R6 gate (resolves the C-125 RT-P2 note)
+- **R6 is satisfied.** The method review's R6 ("sequence Axis B after the C-111 balancer verdict closes") is met: the balancer×seed sweep concluded (`reports/preanalysis_balancer_sweep.md` §RESULT) — active explodes 3/3, frozen is seed-fragile (F2 fired) → **freezing is not the robust fix; exposure bias is the root → do rollout training.** We are not waiting on further balancer work. **Proceed.**
+- **B1 runs `freeze_multitask_balancer=False` (ACTIVE) as the PRIMARY arm.** Active is both the production-intended setting *and* the exploder (baseline `…233938.pt`, ~log 16). The real test is therefore: *does training-through-the-rollout bound the model the active balancer currently blows up?* **Success resolves C-124** — the active (learnable) balancer earns its place once training is honest about the rollout.
+- **Secondary control:** `freeze_multitask_balancer=True` (FROZEN, `…051634.pt`, healthy) — B1 must not break an already-healthy model (also the calibration reference).
+
+### 0.2 P4 — rollout × ZITD coordination (resolves C-129)
+- **Sequence, not concurrent. Axis B goes first.** B1 is a *training-loop-only* change (output stays `log1p`+`expm1` → composable with a later ZITD head); its guard (#76) is in place; ZITD is a larger architectural change; and both edit `training_engine` + the autoregressive feedback, so concurrent development would collide (merge + confounding).
+- **Layering rule:** if B1 bounds the rollout **but** calibration stays wrong (F2 / C-126), the ZITD softplus head is the next layer (it targets calibration directly). If B1 fixes both, ZITD may be deprioritised. A reciprocal one-liner is to be recorded in the ZITD dossier's `02_design`.
+
+## 1. Hypothesis
+**H:** B1 pushforward — train through K autoregressive steps feeding back the model's own one-step-prior prediction (detached across steps; backprop the last step only), adding an **annealed** stability term — makes the **active-balancer** violet model (which currently explodes) keep its **free-running forecast in-range across all 36 steps**, **without degrading calibration** (CRPS / MCR / coverage no worse than the healthy frozen-seed-42 reference).
+
+Dual claim, mirroring the runaway's two faces: B1 fixes the **point/mean** runaway (the C-113 signature) **without** trading it for the **calibration** pathology the panel warned of (mean-hedging / blurring — C-126).
+
+## 2. Intervention & configuration (one variable: the rollout objective)
+- **violet_visitor**, seed 42, **active** balancer (`freeze_multitask_balancer=False`, the exploder); full retrain; everything else per current config except the new `rollout_horizon`.
+- **`rollout_horizon = 12`** (reaches the observed step-12 blow-up onset); pushforward stability term with an **annealed weight** (R1 — → small, CRPS reported uncontaminated); **gradient clipping** (R7).
+- Readout order: **`diagnose_io_gain` free-running attractor (full 36 steps)** (~30 s, retrain-free on the produced artifact) → `--evaluate --saved` for scored CRPS / MCR / calibration.
+- The C-121 guard (`tests/test_rollout_stability_guard.py`) must be green before the retrain (it is).
+
+## 3. Pre-registered predictions
+Baselines: **active-seed42 `…233938`** (stability baseline — the explosion, ~log 16) and **frozen-seed42 `…051634`** (skill/calibration reference — healthy: lr_sb CRPS ≈ 0.197 / ns 0.043 / os 0.052).
+
+| Endpoint | Prediction |
+|---|---|
+| **Stability** (free-running, all 36 steps) | in-range (≲ log 13; vs the active baseline ~log 16); no ratchet |
+| **CRPS** (step-wise, lr_sb/ns/os) | healthy O(0.1), ≤ the frozen reference; **uncontaminated** by the stability term |
+| **MCR** | not worse than the frozen reference; ideally toward 1 |
+| **Calibration / sharpness** | PIT ~uniform, coverage ~nominal; **no mean-hedging collapse** (sharpness/zero-rate not deflated) |
+
+## 4. Falsifiers (pre-committed — any one fires ⇒ MVP rejected, not rescued)
+- **F1 — stability fails:** free-running forecast still leaves the data range with B1 on ⇒ pushforward (one-step-back gradient) is insufficient ⇒ escalate to **B2 GTF** (`02 §7.4`) before scaling.
+- **F2 — calibration traded away (the dangerous one, C-126):** B1 bounds the rollout but MCR/coverage/zero-rate degrade vs the frozen reference (mean-hedging / blurring) ⇒ point-stability bought at the cost of the distribution ⇒ the **ZITD head (P4 layering)** is needed, not more B1.
+- **F3 — truncation blindness (M-RT2 / C-125):** bounded at K=12 but diverges in steps 13–36 ⇒ K too short ⇒ raise K (checkpointed) or re-pre-register.
+- **F4 — proper-score corruption (M-RT1 / C-125):** the stability-term weight isn't annealed and the headline CRPS is contaminated ⇒ the optimum is biased off the true predictive distribution ⇒ fix the objective before trusting CRPS.
+- **F5 — balancer-conditional:** B1+active only bounds when the balancer is *also* frozen ⇒ B1 doesn't fix the exposure bias under the production setting ⇒ Q4 unresolved, **C-124 stays open**, reconsider.
+
+## 5. Metrics & instrumentation
+- **Stability trajectory** — per-step `max|reg|` over 36 steps (the F1/F3 curve), via `free_running_attractor` (the C-121 helper).
+- **CRPS** (proper) step-wise, all 36 steps, per head; **uncontaminated** (R1) — report the predictive CRPS separately from the stability regulariser.
+- **MCR + PIT + coverage (PICP)** — calibration (F2 guard).
+- **Sharpness / zero-rate** — mean-hedging/blurring guard (Shi caution).
+- **Gradient norms** (post-clip, R7) + the stability-weight annealing schedule — training-health record.
+
+## 6. Controls
+- **`rollout_horizon = 1` parity** — byte-identical to today's training path (`02 §8` invariant); confirms B1 is opt-in and inert when off.
+- **Frozen-seed42 arm** (`…051634`) — B1 must not break the already-healthy model; the calibration reference.
+- **pink** — a healthy model under B1 stays healthy (no cost where there was no problem).
+- **Single-seed caveat (C-112)** — MVP is directional (violet/42); confirm on ≥1 more seed before any adoption claim.
+
+## 7. Decision rules
+- **All predictions hold, no falsifier:** B1 succeeds → the C-113 durable fix on the active balancer → **resolves C-124** → multi-seed confirm → promote **ADR-058**. ZITD layering revisited only if calibration needs more.
+- **F1 fires:** escalate to **B2 GTF** (un-detach, soft-mix `(1−α)·pred + α·GT`, α-bounded, gradient clipping).
+- **F2 fires:** B1 stabilises but the distribution suffers → **P4 layering**: bring in the ZITD softplus head.
+- **F3/F4 fire:** config/objective fix (K, annealing) before re-running.
+- **F5 fires:** B1 doesn't fix the exposure bias under the production balancer → C-124 stays open; reconsider.
+- Any outcome → `07_experiment_log` entry; negatives documented, no ad hoc rescue (session discipline).

--- a/reports/2026-06-05_rollout_training_dossier/06_glossary.md
+++ b/reports/2026-06-05_rollout_training_dossier/06_glossary.md
@@ -1,0 +1,34 @@
+# 06 — Glossary (rollout-training program)
+
+**Date:** 2026-06-06 · **Status:** seeded · **Dossier:** [00_README](00_README.md)
+
+Shared vocabulary so the design/plan docs read unambiguously. Grouped by theme.
+
+## The problem
+- **Exposure bias** — the train/inference mismatch: the model is optimised one-step-ahead (teacher-forced) but run free-running at inference, so it never learns to be stable on its own outputs. The deep cause of C-113.
+- **Teacher forcing** — feeding the *ground-truth* previous value as the next input during training.
+- **Free-running / autoregressive rollout** — feeding the model's *own prediction* back as the next input; what inference does for 36 steps.
+- **The feedback operator** — the map `x_t → reg → x_{t+1}` (prediction fed back as input). The io-gain diagnostic localised the runaway here (operator gain `‖J‖₂ > 1`), **not** in the recurrent state.
+- **`detach()` (the severed gradient)** — `training_engine.py:200` (`prev_pred = t1_pred.detach()`): the feedback path carries **no gradient** during training, so the operator that explodes is never trained on its multi-step behaviour. The gap B1 closes.
+- **Attractor / in-range / out-of-range** — the log-space level a free-running rollout settles at; **in-range** ≲ `DATA_LOG_MAX`(12.1)+margin; **out-of-range** ⇒ `expm1` amplifies to catastrophe (the C-113 signature). Measured by `free_running_attractor` / `is_out_of_range`.
+
+## The fixes (Axis B)
+- **B1 — Pushforward** (Brandstetter 2022) — add a stability loss on the prediction made from the model's own one-step-prior prediction; **backprop the last unroll step only** (flat memory). The cheap first cut.
+- **B2 — GTF (Generalized Teacher Forcing)** (Hess 2023) — soft-mix the fed-back signal `(1−α)·pred + α·GT`, keep the gradient, **bound** it via α (scales every Jacobian by `(1−α)`). The principled fallback if B1 under-delivers.
+- **B3 — Professor Forcing** (Lamb 2016) — adversarial discriminator matching free-running vs teacher-forced *dynamics*. The maximal option; catalogued, not first.
+- **`rollout_horizon` (K)** — the config HP: how many autoregressive steps to train through (the "look-ahead depth"). Candidate K=12; K=1 = today's one-step path (parity).
+- **`L_stability` (stability term)** — the pushforward regulariser; **annealed/small-weighted**, never replaces the proper score (R1).
+- **Annealing** — decaying the stability weight (B1) or α from 1→α* (B2) over training.
+- **Truncated BPTT (TBPTT)** — backprop through K<full steps; biased for dependencies > K (the F3/M-RT2 concern).
+- **Zero-stability** (Hairer) — `‖A(u⁰+ε) − u¹‖ < κ‖ε‖`; pushforward minimises κ.
+
+## Evaluation
+- **Proper scoring rule / CRPS** — a score minimised in expectation by the true predictive distribution; the **uncontaminated headline** metric (Gneiting & Raftery 2007).
+- **MCR** — mean calibration ratio; chronic ≪ 1 = under-prediction.
+- **PIT / coverage (PICP)** — probability-integral-transform uniformity / interval coverage vs nominal; the calibration checks.
+- **Mean-hedging / blurring** — multi-step optimisation collapsing toward the spatial/temporal mean (a known ConvLSTM-rollout failure); the F2/C-126 risk — "bounded but mis-calibrated."
+
+## Program / governance shorthand
+- **R1–R7** — the method-review fixes folded into `02_design` §10.
+- **C-113** the runaway · **C-121** the guard · **C-124** balancer benefit · **C-125** rollout premises · **C-126** point-vs-calibration · **C-129** rollout×ZITD coordination.
+- **ADR-058** — the candidate ADR this dossier graduates to on a B1 win.

--- a/reports/2026-06-05_rollout_training_dossier/07_experiment_log.md
+++ b/reports/2026-06-05_rollout_training_dossier/07_experiment_log.md
@@ -26,9 +26,24 @@ Legend: ✅ predictions held · 🔴 falsifier fired · ⚪ inconclusive.
 
 ## Planned
 
-### EXP-01 — B1 pushforward MVP  (planned)
-- Pre-registration: [`05_analysis_plan.md`](05_analysis_plan.md)
-- One variable: `rollout_horizon` (pushforward stability term) on violet/seed-42, **active** balancer.
-- Gated on: `03 §5` pre-flight green (the §3 harness build, P1/P2) + GPU.
-- Baselines: `…233938` (active exploder, stability) · `…051634` (frozen healthy, calibration).
-- *(awaiting execution — no outcome yet; this is the open pre-registration the dossier `status` tracks)*
+### EXP-01 — Scheduled-sampling always-feed (`ss_epsilon_max` 0.25 → 1.0)  (2026-06-06) ⚠️
+- **What & why:** the "just try a fix" cheap stab — crank own-prediction training to the max. The cross-step gradient stays **detached**, so this is the crude *per-step* proxy, **not** the `rollout_horizon` B1 of `05` (which remains the real build). Surfaced via `02c`.
+- **One variable:** `ss_epsilon_max` 0.25 → 1.0 on **violet / seed-42, active balancer**.
+- **Driver / artifact / log:** `views-models/scripts/run_ss_alwaysfeed.sh` · `calibration_model_20260606_190457.pt` · `logs/ss_alwaysfeed_20260606_171806.log`. Config trap-restored to 0.25 after.
+- **Readout (`diagnose_io_gain`, synthetic):** the free-running rollout **stops exploding** — but **collapses to 0.00** by step ~12 (step1 ≈1.0 → step12/24/48 = 0.00; expm1 = 0). Local operator gain still ‖J‖₂>1, but the attractor moved to the trivial **zero fixed point**.
+- **Verdict vs falsifiers:** runaway **gone** (no out-of-range) — but this is the **"bounded but useless"** collapse the panel *and the chair* predicted (C-126 family): bounded by going degenerate, not by forecasting. ⚠️ **partial — cured the explosion by killing the forecast.**
+- **Caveat:** synthetic probe; healthy pink settles nonzero-in-range, this flatlines to 0 → strong collapse signal, but real-data skill not yet confirmed (folded into EXP-02's readout).
+- **Decision:** → method review `02d` → run the **middle ceiling** (EXP-02) with a **real eval**, then build the structured (c) GTF.
+- **Evidence added to the axis:** ceiling **0.25 → explode**, **1.0 → collapse** — brackets the scheduled-sampling-intensity axis.
+
+### EXP-02 — Scheduled-sampling middle ceiling (`ss_epsilon_max` ≈ 0.5) + real eval  (planned · pre-registered here)
+- **Hypothesis:** plain scheduled-sampling has a stable-*nonzero* regime somewhere between explode (0.25) and collapse (1.0). *(Prior is low — see the knife-edge risk RT-knifeedge + Huszár bias; this is a VoI **gate**, not a candidate endpoint.)*
+- **One variable:** `ss_epsilon_max` → ~0.5 on violet/seed-42, active balancer. (The dial already ramps low→ceiling; we only lower the ceiling.)
+- **Readout:** BOTH `diagnose_io_gain` (stability across 36) **and a real `--evaluate`** (CRPS/MCR — *skill*, not just boundedness). **Do not judge on the synthetic probe alone** (the 1.0 collapse read "healthy" at 0.00).
+- **Pre-registered decision rule:**
+  - **stable ∧ nonzero ∧ nontrivial skill** ⇒ plain-SS *has* a regime (cheap, surprising win) → confirm on a 2nd seed.
+  - **explode ∨ collapse ∨ stable-but-zero-skill** ⇒ plain-SS has **no good regime** (confirmed, not assumed) → commit to **(c) GTF**.
+- Baselines: `…233938` (explode) · `…051634` (frozen-healthy, calibration ref).
+
+### Later — the real build (c): controlled unroll-K / GTF
+- Pre-registration: [`05_analysis_plan.md`](05_analysis_plan.md) (the `rollout_horizon` B1/GTF MVP). Gated on the `03 §3` harness build. The chair's "scheduler, start-low-get-higher" instinct **is** GTF's α-anneal ⇒ build **B2-flavoured** (bounded cross-step gradient), not just a deeper pushforward.

--- a/reports/2026-06-05_rollout_training_dossier/07_experiment_log.md
+++ b/reports/2026-06-05_rollout_training_dossier/07_experiment_log.md
@@ -1,0 +1,34 @@
+# 07 — Experiment Log (append-only)
+
+**Date:** 2026-06-06 · **Status:** seeded (skeleton) · **Dossier:** [00_README](00_README.md)
+
+Append-only ledger of every run + outcome — **including negatives/postmortems**. Each entry links its pre-registration (`05` or a `preanalysis_*.md`) and records its **verdict against the pre-registered falsifiers**. This is a Popperian record *and* a meta-evaluation corpus (later used to assess the workflow + the skills) — **not a highlight reel**. No ad hoc rescue.
+
+## Entry format
+```
+### EXP-NN — <title>  (YYYY-MM-DD)
+- Pre-registration: <link to 05 / preanalysis_*.md>
+- One variable: <the single change vs baseline>
+- Driver / artifact / results: <run_*.sh · model_*.pt · logs/*_RESULTS.txt>
+- Readout: <diagnose_io_gain attractor · step-wise CRPS · MCR/PIT/coverage · sharpness>
+- Verdict vs falsifiers: <which fired / none>
+- Decision: <proceed / escalate (B2/ZITD) / postmortem link>
+```
+Legend: ✅ predictions held · 🔴 falsifier fired · ⚪ inconclusive.
+
+---
+
+## Precursors (done — the evidence base this program builds on)
+- **`results_freezeh_ablation.md`** — freeze_h inert; divergence rides the prediction→input feedback, not the recurrent state.
+- **`results_io_gain_diagnostic.md`** — violet's free-running map settles out-of-range (~log 40 → expm1 ~1e17); `diagnose_io_gain` is the fast readout.
+- **`results_feedback_clamp.md`** — clamping the feedback is a safety rail, not a fix (ramps-to-ceiling).
+- **`preanalysis_balancer_sweep.md` §RESULT** — F2 fired (seed4_frozen → inf): freezing is seed-fragile; exposure bias is the root → do rollout training.
+
+## Planned
+
+### EXP-01 — B1 pushforward MVP  (planned)
+- Pre-registration: [`05_analysis_plan.md`](05_analysis_plan.md)
+- One variable: `rollout_horizon` (pushforward stability term) on violet/seed-42, **active** balancer.
+- Gated on: `03 §5` pre-flight green (the §3 harness build, P1/P2) + GPU.
+- Baselines: `…233938` (active exploder, stability) · `…051634` (frozen healthy, calibration).
+- *(awaiting execution — no outcome yet; this is the open pre-registration the dossier `status` tracks)*

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -5,8 +5,8 @@
 | Project           | views-hydranet                       |
 | Owner             | Simon Polichinel von der Maase       |
 | Last Updated      | 2026-06-05                           |
-| Total Concerns    | 126                                  |
-| Open Concerns     | 32                                   |
+| Total Concerns    | 127                                  |
+| Open Concerns     | 33                                   |
 | — of which demoted (tech-debt) | 4 (tagged `[DEMOTED]` in §Open Concerns; indexed in §Tech-Debt Backlog) |
 | Resolved Concerns | 94                                   |
 
@@ -579,6 +579,8 @@ The Axis-B design adds a multi-step rollout objective to fix the C-113 runaway. 
 
 Tier 3 rationale: design-stage methodology gaps for an as-yet-unbuilt feature; no current silent corruption, but each could mis-direct the C-113 fix or ship a subtly biased forecaster. Mitigation: the pre-analysis plan (`05`) pre-registers (a)/(b)/(c) as binding guardrails + falsifiers before any full retrain; fetch Mikhaeil 2022 to settle (c). Promote to Tier 2 if rollout training is implemented without these guards.
 
+*Update (falsify, 2026-06-06) — sequencing/decision gap (RT-P2):* concluding B1 also requires a **decided MultiTaskLoss balancer config** to retrain under (C-124 open: active destabilises, frozen is seed-fragile) **and** resolution of the **circular R6 gate** — `02_design` §7.0 says "sequence Axis B after the C-111 balancer verdict closes," but C-124 stays open and *defers to Axis B as the fix*, so R6 cannot close on its own terms. Record the balancer-config decision + an explicit "R6 satisfied / proceed" call in the pre-analysis plan (`05`). A RED stub marks the gap: `tests/test_falsification_rollout_plan.py`. Cross-ref C-124.
+
 ---
 
 ### C-126: Rollout-training success metric conflates point-stability with calibration
@@ -631,6 +633,23 @@ Tier 4 rationale: linter-visible (ruff F601, not silent), values mostly identica
 ADR-057 makes inference use a **locked** dropout mask (fixed across the 36-step roll-forward, fresh per posterior sample) instead of per-step fresh masks, and PR #75 turns this **on by default** (unconditional at `HydraNetInference.__init__`). The locked mask **narrows the posterior spread** vs per-step dropout, so MCR/coverage can shift. It was **spot-checked benign on `pink_pirate`** (the freeze_h characterization eval reproduced pink's reference CRPS/MCR), but the planned cross-model calibration analysis (dossier I3 — "is the fixed-mask posterior calibrated or too tight?") has **not** been run on the other members. Risk: a delivered posterior could be silently mis-calibrated (too tight) on an unchecked model with no error signal — the C-110-style silent-miscalibration failure mode.
 
 Tier 3 rationale: a **validation gap**, not a known defect — spot-checked benign on pink, MC-dropout was already approximate, and the change is intended (ADR-057, consciously accepted at the #75 merge). Escalate to Tier 2 (à la C-110) if a locked-mask posterior is relied on for delivery before I3. Mitigation: run the I3 calibration analysis (PIT/coverage + MCR) across models; or gate locked dropout behind an opt-in flag if I3 is deferred.
+
+---
+
+### C-129: Rollout-training (Axis B) × ZITD distributional-head coordination is untracked
+
+| Field | Value |
+|-------|-------|
+| ID | C-129 |
+| Tier | 3 |
+| Source | falsify (2026-06-06, "nothing blocks concluding Axis B" audit, P4) |
+| Trigger | Progressing the Axis-B rollout-training (B1) and the ZITD distributional head independently — each editing `training_engine` and the `log1p` autoregressive feedback — without a coordination plan for how they compose or which lands first |
+| Location | `reports/2026-06-05_rollout_training_dossier/02_design.md` + `reports/2026-06-05_distributional_head_dossier/02_design.md`; `views_hydranet/train/training_engine.py` (rollout loss + feedback); the autoregressive feedback re-encoding |
+| Cross-refs | C-125/C-126 (rollout premises / calibration), C-113 (the shared target), the two dossiers |
+
+The two active research programs both modify the **same** training loop and the **same** autoregressive feedback path, but their **interaction is unanalysed**. The rollout dossier declares itself "distinct from the ZITD dossier"; the ZITD dossier never mentions Axis B. Yet B1's rollout loss would have to train *through* ZITD's feedback re-encoding (`log1p(mean or sample)` from a softplus-link distributional head), and ZITD's softplus link is itself the *other* proposed cure for the same `expm1` runaway. Open questions neither plan owns: do B1 (rollout gradients) and ZITD (output representation) compose or conflict? Which lands first? Does B1's stability term interact with ZITD's NLL/CRPS objective? Left untracked, the two could collide in `training_engine` (merge/sequencing) and in feedback semantics.
+
+Tier 3 rationale: a cross-program coordination/dependency gap (no silent corruption today), but it raises cost-of-change and could mis-sequence the two largest research efforts. Mitigation: a one-paragraph coordination note in each dossier's `02_design` (or a shared sequencing decision) — likely "ship one cure for the runaway first (Axis B *or* the ZITD softplus link), measure, then layer the other," recorded before either retrain.
 
 ---
 

--- a/tests/test_falsification_clean_base.py
+++ b/tests/test_falsification_clean_base.py
@@ -7,8 +7,9 @@ development HEAD 77a3e2e). But the *broad* reading ("ready to barrel ahead")
 is SOFT-falsified: the base still carries OPEN Tier-2 risks — chiefly C-113
 (autoregressive runaway, UNFIXED) with NO automated regression guard (C-121).
 The next step (rollout-training) involves RETRAINS — exactly the trigger under
-which C-113 can silently recur. RESOLVED 2026-06-06: the guard landed (#76 -> tests/test_rollout_stability_guard.py
-+ views_hydranet/utils/rollout_diagnostics.py). This test is now GREEN, retained as a
+which C-113 can silently recur. RESOLVED 2026-06-06: the guard landed (#76 ->
+tests/test_rollout_stability_guard.py + views_hydranet/utils/rollout_diagnostics.py).
+This test is now GREEN, retained as a
 meta-guard that fails if the C-113 runaway guard is ever deleted (C-121).
 
 Observation (P4, FIXED 2026-06-06): ADR-057's `**Branch:**` field still names the now-

--- a/tests/test_falsification_loss_param_validation.py
+++ b/tests/test_falsification_loss_param_validation.py
@@ -12,7 +12,7 @@ class TestF5_CICFieldCountDrift:
 
     def test_cic_field_count_matches_actual(self):
         """CIC §3 field count must match actual model_fields count."""
-        CIC_CLAIMED_COUNT = 70  # from docs/CICs/HydraNetConfig.md §3 (freeze_h retired 2026-06-05)
+        CIC_CLAIMED_COUNT = 71  # docs/CICs/HydraNetConfig.md §3 (freeze_h retired -1; rollout_horizon +1, 2026-06-06)
         actual = len(HydraNetConfig.model_fields)
         assert actual == CIC_CLAIMED_COUNT, (
             f"CIC §3 claims {CIC_CLAIMED_COUNT} fields but HydraNetConfig has {actual}. "

--- a/tests/test_falsification_loss_param_validation.py
+++ b/tests/test_falsification_loss_param_validation.py
@@ -12,7 +12,8 @@ class TestF5_CICFieldCountDrift:
 
     def test_cic_field_count_matches_actual(self):
         """CIC §3 field count must match actual model_fields count."""
-        CIC_CLAIMED_COUNT = 71  # docs/CICs/HydraNetConfig.md §3 (freeze_h retired -1; rollout_horizon +1, 2026-06-06)
+        # docs/CICs/HydraNetConfig.md §3 (freeze_h retired -1; rollout_horizon +1, 2026-06-06)
+        CIC_CLAIMED_COUNT = 71
         actual = len(HydraNetConfig.model_fields)
         assert actual == CIC_CLAIMED_COUNT, (
             f"CIC §3 claims {CIC_CLAIMED_COUNT} fields but HydraNetConfig has {actual}. "

--- a/tests/test_falsification_rollout_plan.py
+++ b/tests/test_falsification_rollout_plan.py
@@ -20,9 +20,7 @@ names the chosen setting. (P4 is tracked as a register finding, not a code test.
 import pathlib
 
 _DOSSIER = (
-    pathlib.Path(__file__).resolve().parents[1]
-    / "reports"
-    / "2026-06-05_rollout_training_dossier"
+    pathlib.Path(__file__).resolve().parents[1] / "reports" / "2026-06-05_rollout_training_dossier"
 )
 
 

--- a/tests/test_falsification_rollout_plan.py
+++ b/tests/test_falsification_rollout_plan.py
@@ -1,0 +1,46 @@
+"""Falsification stubs — audit of "nothing (untracked) blocks working on + concluding
+Axis B (rollout-training dossier)" (/falsify, 2026-06-06).
+
+VERDICT: CONTESTED. "Working on" is unblocked and in-plan (guard done, 05/03 are named
+next-actions, GPU-gating tracked in #78). "Concluding" carries two SOFT, unresolved
+items the plan flags but does not settle:
+  P2 — the balancer config the B1 retrain runs under is undecided, and the R6 gate
+       ("sequence after the C-111 balancer verdict closes") is circular: C-124 stays
+       open and defers to Axis B, while Axis B is gated on C-124. Status unresolved.
+  P4 — the rollout (loss/feedback) x ZITD distributional-head (output/feedback)
+       interaction is untracked: both modify training_engine + the log1p autoregressive
+       feedback; the rollout dossier says "distinct from ZITD" but the *interaction*
+       is not analysed as a dependency (the ZITD dossier never mentions Axis B).
+
+These red stubs enforce the concrete next artifact: a pre-registered B1 experiment plan
+(dossier 05) that records the balancer-config decision. They go green when 05 exists and
+names the chosen setting. (P4 is tracked as a register finding, not a code test.)
+"""
+
+import pathlib
+
+_DOSSIER = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "reports"
+    / "2026-06-05_rollout_training_dossier"
+)
+
+
+def test_rollout_preanalysis_plan_exists():
+    """Concluding Axis B needs a pre-registered B1 experiment (dossier 05). RED until written."""
+    assert (_DOSSIER / "05_analysis_plan.md").exists(), (
+        "rollout-training dossier has no 05_analysis_plan.md — the pre-registered B1 "
+        "experiment (readout + falsifiers) needed to work toward concluding Axis B (#77/#78)."
+    )
+
+
+def test_rollout_b1_balancer_config_decided():
+    """The B1 retrain needs a decided balancer setting (C-124 open: active destabilises,
+    frozen is seed-fragile; the R6 sequencing gate is circular). RED until dossier 05
+    records which MultiTaskLoss balancer config B1 runs under."""
+    plan = _DOSSIER / "05_analysis_plan.md"
+    text = plan.read_text() if plan.exists() else ""
+    assert "freeze_multitask_balancer" in text, (
+        "No documented decision on which MultiTaskLoss balancer config the B1 retrain "
+        "runs under (C-124 open; R6 gate circular). Record the chosen setting in dossier 05."
+    )

--- a/tests/test_rollout_horizon_config.py
+++ b/tests/test_rollout_horizon_config.py
@@ -1,0 +1,24 @@
+"""rollout_horizon config field — the flag the B1 pushforward path will sit behind
+(rollout-training dossier, #78). Increment 1: the field exists, defaults to 1 (= today's
+one-step path → parity), and enforces >= 1. No training-loop behavior change yet — the
+field is inert until the pushforward path reads it (increment 2).
+
+ADR-005 Green/Red taxonomy. See reports/2026-06-05_rollout_training_dossier/03_harness_and_invariants.md.
+"""
+
+from views_hydranet.utils.config_initializer import HydraNetConfig
+
+
+def test_rollout_horizon_field_exists_and_defaults_to_one():
+    """Green: the field exists and defaults to 1 — K=1 is the current one-step path (parity)."""
+    assert "rollout_horizon" in HydraNetConfig.model_fields, "rollout_horizon field missing"
+    assert HydraNetConfig.model_fields["rollout_horizon"].default == 1
+
+
+def test_rollout_horizon_enforces_ge_one():
+    """Red-catcher: a horizon < 1 is meaningless → the field must enforce >= 1 (the parity floor)."""
+    field = HydraNetConfig.model_fields["rollout_horizon"]
+    metadata = getattr(field, "metadata", [])
+    assert any(getattr(m, "ge", None) == 1 for m in metadata), (
+        "rollout_horizon must enforce >= 1 (ge=1); K=1 is the parity floor."
+    )

--- a/tests/test_rollout_horizon_config.py
+++ b/tests/test_rollout_horizon_config.py
@@ -3,7 +3,8 @@
 one-step path → parity), and enforces >= 1. No training-loop behavior change yet — the
 field is inert until the pushforward path reads it (increment 2).
 
-ADR-005 Green/Red taxonomy. See reports/2026-06-05_rollout_training_dossier/03_harness_and_invariants.md.
+ADR-005 Green/Red taxonomy. See reports/2026-06-05_rollout_training_dossier/
+03_harness_and_invariants.md.
 """
 
 from views_hydranet.utils.config_initializer import HydraNetConfig
@@ -16,7 +17,7 @@ def test_rollout_horizon_field_exists_and_defaults_to_one():
 
 
 def test_rollout_horizon_enforces_ge_one():
-    """Red-catcher: a horizon < 1 is meaningless → the field must enforce >= 1 (the parity floor)."""
+    """Red-catcher: a horizon < 1 is meaningless → the field must enforce >= 1 (parity floor)."""
     field = HydraNetConfig.model_fields["rollout_horizon"]
     metadata = getattr(field, "metadata", [])
     assert any(getattr(m, "ge", None) == 1 for m in metadata), (

--- a/views_hydranet/utils/config_initializer.py
+++ b/views_hydranet/utils/config_initializer.py
@@ -147,6 +147,16 @@ class HydraNetConfig(BaseModel):
             "reports/preanalysis_balancer_bisect.md."
         ),
     )
+    rollout_horizon: int = Field(
+        default=1,
+        ge=1,
+        description=(
+            "C-113 / Axis B: number of autoregressive steps to train through "
+            "(the rollout-training 'look-ahead'). Default 1 = the current one-step "
+            "path (byte-identical parity); >1 enables the B1 pushforward stability "
+            "term. Candidate K=12. See reports/2026-06-05_rollout_training_dossier/."
+        ),
+    )
     sweep: bool = Field(default=False)
     random_flips: bool = Field(default=True)
     diagnostic_visualizations: bool = Field(default=False)


### PR DESCRIPTION
Pre-registers the first rollout-training experiment and closes the two gaps the `/falsify` audit surfaced (verdict CONTESTED → now resolved).

## What's here
- **`05_analysis_plan.md` (new)** — pre-registered B1 pushforward MVP: hypothesis (B1 bounds the 36-step rollout *without* degrading calibration), one-variable intervention (`rollout_horizon=12`, annealed stability term, gradient clipping), predictions, falsifiers, metrics, controls, decision rules.
  - **§0.1 (P2):** R6 satisfied (balancer sweep concluded); **primary arm = active balancer** (the exploder) → success resolves C-124; frozen = control.
  - **§0.2 (P4):** **Axis B sequenced before ZITD** (training-only, composable, guarded); ZITD layered after only if calibration needs it.
- **Register:** new **C-129** (rollout×ZITD coordination) + C-125 RT-P2 note.
- **`tests/test_falsification_rollout_plan.py`** — the 2 falsify stubs, now **GREEN** (meta-guards: `05` exists + records the balancer decision).
- **README** synced: `02` R1–R7 folded, `05` seeded, R6 marked satisfied.

## Verification
ruff ✓ · 707 passed / 7 skipped / 10 xfailed ✓.

## Scope
Planning/doc only — no training-loop or GPU change. Remaining doc gate before B1 (#78) is `03_harness` (next). Refs #77/#78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)