### PR TITLE
fix(#144): derive grid id-column from data (priogrid_gid → priogrid_id agnostic)

### DIFF
--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -195,8 +195,12 @@ class TestRed:
             DataFetcher.standardize_raw_df(df, _base_config())
 
     def test_red_wrong_level_names_raises(self):
-        """Wrong MultiIndex names -> ValueError."""
-        idx = pd.MultiIndex.from_arrays([[1, 2], [3, 4]], names=["wrong_a", "wrong_b"])
+        """Wrong TIME level (grid present, derived) still -> Contract Violation ValueError.
+
+        GH #144: the grid level is derived by name, so to exercise the level-0/time contract check
+        we keep a valid grid level and break the time level. (A *missing* grid level is covered by
+        grid_id_col's fail-loud in test_grid_naming.py.)"""
+        idx = pd.MultiIndex.from_arrays([[1, 2], [3, 4]], names=["wrong_time", "priogrid_gid"])
         df = pd.DataFrame({"a": [1, 2]}, index=idx)
         with pytest.raises(ValueError, match="Contract Violation"):
             DataFetcher.standardize_raw_df(df, _base_config())
@@ -208,14 +212,13 @@ class TestRed:
         with pytest.raises(KeyError, match="index_names"):
             DataFetcher.standardize_raw_df(df, cfg)
 
-    def test_red_missing_id_col_raises(self):
-        """id_col absent after reset -> KeyError."""
-        idx = pd.MultiIndex.from_arrays([[1, 2], [3, 4]], names=INDEX_NAMES)
-        df = pd.DataFrame({"a": [1, 2]}, index=idx)
-        # Use a bogus id_col that won't exist after reset
-        cfg = _base_config(id_col="nonexistent_col")
-        with pytest.raises(KeyError, match="nonexistent_col"):
-            DataFetcher.standardize_raw_df(df, cfg)
+    def test_stale_config_id_col_is_ignored_grid_derived_from_data(self):
+        """GH #144: the (possibly stale) config id_col is IGNORED — the grid column is derived from
+        the data. A bogus config id_col no longer raises; the real grid column is used."""
+        df = _make_multiindex_df()  # index = [month_id, priogrid_gid]
+        cfg = _base_config(id_col="nonexistent_col")  # stale/bogus — must be ignored
+        out = DataFetcher.standardize_raw_df(df, cfg)
+        assert "priogrid_gid" in out.columns  # derived from the data, not the config name
 
     def test_red_blueprint_unknown_op_raises(self):
         """Unknown operation -> NotImplementedError."""

--- a/tests/test_grid_naming.py
+++ b/tests/test_grid_naming.py
@@ -1,0 +1,74 @@
+"""TDD: grid-name-agnostic loading (GH #144) — the platform priogrid_gid -> priogrid_id flip.
+
+views-hydranet reads the cached parquet DIRECTLY off disk (data_fetcher.py:59), bypassing
+pipeline-core's normalization, so it must resolve the grid entity from the DATA, not a hardcoded
+literal or a (possibly stale) config. `grid_id_col` is the single rule — name-set membership,
+fail-loud. `standardize_raw_df` and `mcr_readout.load_truth_index` must then tolerate EITHER grid
+name even when the config still says the legacy `priogrid_gid`.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pytest.importorskip("views_pipeline_core")
+
+from views_hydranet.utils.data_fetcher import DataFetcher  # noqa: E402
+from views_hydranet.utils.grid_naming import GRID_ID_ALIASES, grid_id_col  # noqa: E402
+
+
+# ---- grid_id_col: the single rule (semantic, fail-loud) ----
+def test_resolves_legacy_and_canonical_names():
+    assert grid_id_col(["month_id", "priogrid_gid"]) == "priogrid_gid"
+    assert grid_id_col(["month_id", "priogrid_id"]) == "priogrid_id"
+
+
+def test_works_on_columns_not_just_index_levels():
+    assert grid_id_col(pd.Index(["c_id", "priogrid_id", "row"])) == "priogrid_id"
+
+
+def test_fail_loud_when_no_grid_col():
+    with pytest.raises(ValueError):
+        grid_id_col(["month_id", "country_id"])
+
+
+def test_fail_loud_when_ambiguous():
+    with pytest.raises(ValueError):
+        grid_id_col(["priogrid_gid", "priogrid_id"])
+
+
+def test_canonical_listed_first():
+    assert GRID_ID_ALIASES[0] == "priogrid_id"
+
+
+# ---- characterization: standardize tolerates EITHER grid name with a STALE config ----
+def _df(grid_name, n_t=4, n_c=4, ocean=False):
+    times = np.repeat(np.arange(1, n_t + 1), n_c)
+    cells = np.tile(np.arange(1, n_c + 1), n_t).astype(float)
+    if ocean:
+        cells[0] = 0.0  # an ocean cell (grid id 0)
+    idx = pd.MultiIndex.from_arrays([times, cells], names=["month_id", grid_name])
+    return pd.DataFrame(
+        {"lr_ged_sb": np.random.rand(len(times)), "feat_a": np.random.rand(len(times))},
+        index=idx,
+    )
+
+
+_STALE_CFG = {
+    "index_names": ["month_id", "priogrid_gid"],  # config still says LEGACY (pre-tidy)
+    "time_col": "month_id",
+    "id_col": "priogrid_gid",
+    "derivations": {},
+}
+
+
+@pytest.mark.parametrize("grid_name", ["priogrid_gid", "priogrid_id"])
+def test_standardize_tolerates_either_grid_name_with_stale_config(grid_name):
+    out = DataFetcher.standardize_raw_df(_df(grid_name), dict(_STALE_CFG))
+    assert grid_name in out.columns  # the DERIVED grid col survives reset_index
+
+
+@pytest.mark.parametrize("grid_name", ["priogrid_gid", "priogrid_id"])
+def test_ocean_filter_uses_the_derived_grid_col(grid_name):
+    out = DataFetcher.standardize_raw_df(_df(grid_name, ocean=True), dict(_STALE_CFG))
+    assert (out[grid_name] > 0).all()  # grid==0 ocean dropped via the derived col, not the config

--- a/views_hydranet/utils/data_fetcher.py
+++ b/views_hydranet/utils/data_fetcher.py
@@ -11,6 +11,7 @@ import pandas as pd
 from views_pipeline_core.configs.pipeline import PipelineConfig
 from views_pipeline_core.files.utils import read_dataframe
 
+from views_hydranet.utils.grid_naming import grid_id_col
 from views_hydranet.utils.utils_logging import log_data_load_report
 
 logger = logging.getLogger(__name__)
@@ -85,7 +86,7 @@ class DataFetcher:
 
         # 2. Enforce Level Names and Order from Config (ADR 017 Section 1.2)
         try:
-            expected_names = config["index_names"]
+            expected_names = list(config["index_names"])
         except KeyError:
             err_msg = (
                 "DataFetcher Contract Violation: 'index_names' missing from config.\n"
@@ -97,6 +98,14 @@ class DataFetcher:
             raise KeyError(err_msg)
 
         actual_names = list(df.index.names)
+
+        # GH #144: resolve the grid entity from the DATA (priogrid_gid <-> priogrid_id flip), so a
+        # stale config name does not reject a renamed cache. grid_id_col is fail-loud (guards a
+        # malformed index); we then expect that derived name at the grid level (level-0/time below
+        # is still enforced). Backward-compatible: for today's priogrid_gid data this is a no-op.
+        id_col = grid_id_col(actual_names)
+        if len(expected_names) >= 2:
+            expected_names[1] = id_col
 
         if actual_names[: len(expected_names)] != expected_names:
             err_msg = (
@@ -115,7 +124,7 @@ class DataFetcher:
         # 4. Sort-Order Assertion (Hypothesis 5 Probe)
         # We must ensure time is monotonic for the VolumeHandler to work correctly.
         time_col = config.get("time_col", "month_id")
-        id_col = config.get("id_col", "priogrid_gid")
+        # id_col was derived from the data above (GH #144), not the (possibly stale) config name.
 
         if time_col in df_flat.columns:
             if not df_flat[time_col].is_monotonic_increasing:

--- a/views_hydranet/utils/grid_naming.py
+++ b/views_hydranet/utils/grid_naming.py
@@ -1,0 +1,34 @@
+"""Single source of truth for the VIEWS grid-entity column name (GH #144).
+
+The platform is consolidating the PGM grid index name (views-frames ADR-015): the legacy
+``priogrid_gid`` (UCDP/PRIO-GRID source name) and the canonical ``priogrid_id`` are both in
+circulation. views-hydranet reads cached parquet DIRECTLY off disk (data_fetcher reads
+``data/raw/*.parquet`` without going through pipeline-core's normalization), so it must resolve the
+grid entity from the DATA — not a hardcoded literal or a (possibly stale) model config.
+
+This module is that one rule. Its load-bearing consumers — ``data_fetcher`` (load path) and
+``mcr_readout`` (prediction↔truth join key) — depend on it so the name lives in exactly one place.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+# Canonical first (views-frames ADR-015), legacy second. Membership is what matters, not order.
+GRID_ID_ALIASES = ("priogrid_id", "priogrid_gid")
+
+
+def grid_id_col(names: Iterable[str]) -> str:
+    """Resolve the grid-entity column among ``names`` (index levels OR DataFrame columns).
+
+    Resolves by NAME-SET membership, not position — a reordered or extra index level cannot
+    silently mis-resolve (a positional ``names[1]`` could). Fail-loud: raises if zero or more than
+    one alias is present, preserving the load path's existing loud-failure contract.
+    """
+    names = list(names)
+    found = [n for n in names if n in GRID_ID_ALIASES]
+    if len(found) != 1:
+        raise ValueError(
+            f"grid id column: expected exactly one of {GRID_ID_ALIASES}, found {found} in {names}"
+        )
+    return found[0]


### PR DESCRIPTION
## What
`data_fetcher` now derives the PGM grid id-column **from the data** (`grid_naming.grid_id_col` — name-set membership over `{priogrid_id, priogrid_gid}`, fail-loud), instead of a hardcoded/stale config name.

## Why (load-bearing, GH #144)
views-hydranet reads cached parquet directly off disk, bypassing pipeline-core's normalization. Once pipeline-core writes `priogrid_id` caches, hydranet would resolve `priogrid_gid` and raise `KeyError`, breaking every PGM model. This makes hydranet **agnostic to the flip** — backward-compatible (works with today's `priogrid_gid` AND tomorrow's `priogrid_id`), so it can land **ahead of** the pipeline-core consolidation and unblocks the downstream repos.

## Scope
Load path only: `grid_naming.py` (new SSOT), `data_fetcher.py`, + parametrized tests. `mcr_readout.py`'s matching join-key fix lives on `feat/zinb-distributional-head` (that file isn't in `development` yet) and rides along when that branch merges.

## Tests
- `tests/test_grid_naming.py` — parametrized over both cache variants (RED→GREEN); fail-loud + ambiguity cases.
- Two obsolete config-`id_col` tests updated to the derive-from-data contract.
- 26 passed, ruff clean.

## Follow-up (separate, non-load-bearing)
Drop the `id_col`/`index_names` config knobs in the PGM models + fix the two stale fixtures.

Closes #144.
