### PR TITLE
fix(ci): make merge-readiness ruff tests skip when ruff is absent (unblock test job)

### DIFF
--- a/tests/test_falsification_merge_readiness.py
+++ b/tests/test_falsification_merge_readiness.py
@@ -10,7 +10,10 @@ Two soft falsifications: lint/format violations in PR files, mixed branch scope.
 
 from __future__ import annotations
 
+import shutil
 import subprocess
+
+import pytest
 
 
 class TestFalsifyP1UncommittedWork:
@@ -47,6 +50,10 @@ class TestFalsifyP1UncommittedWork:
         )
 
 
+@pytest.mark.skipif(
+    shutil.which("ruff") is None,
+    reason="ruff not on PATH (e.g. CI test env); the dedicated lint job covers ruff check/format.",
+)
 class TestFalsifyP2LintAndFormat:
     """
     Probe 2 (Category A — Regression): Lint and format violations in PR files.


### PR DESCRIPTION
Follow-up to #252. views-pipeline-core 3.0.0 is live so CI's env now builds and the suite runs (1239 passed) — but the test job stayed red on 2 self-referential `ruff`-subprocess tests (TestFalsifyP2LintAndFormat) that fail with FileNotFoundError because `ruff` isn't installed in the test env (only the lint job has it). Guarded the class with `skipif(shutil.which('ruff') is None)` — self-skips where ruff is absent, still runs where present; the lint job covers ruff. Expect a GREEN test job on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)