### PR TITLE
fix(repo): track the three reports/ scorers that tracked code depends on

### DIFF
--- a/reports/2026-07-15_volatility_ceiling_dossier/tools/s5_tail.py
+++ b/reports/2026-07-15_volatility_ceiling_dossier/tools/s5_tail.py
@@ -1,0 +1,105 @@
+"""S5 STRETCH — tail-family adequacy (EVT/GPD diagnostic).
+
+Peaks-over-threshold: fit a Generalized Pareto to exceedances of the conflict-count target, estimate the
+tail index xi (heaviness), and test whether the LIGHT families the head could use (geometric-ish NB with
+theta~=0.98, or lognormal) structurally under-cover the extreme tail. Also: is xi state-varying (can a
+head predict tail HEAVINESS, not just whether-volatile)? Diagnostic only — informs the head spec; the lab
+demoted a GPD *head* before, so we probe whether the FAMILY matters, we don't commit to one.
+
+Usage: s5_tail.py <parquet> <out_json>
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+
+def gpd_xi(exceed):
+    from scipy.stats import genpareto
+    if exceed.size < 50:
+        return {"n": int(exceed.size), "xi": None}
+    c, loc, scale = genpareto.fit(exceed, floc=0.0)
+    return {"n": int(exceed.size), "xi": float(c), "scale": float(scale)}
+
+
+def tail_prob_nb(mu, theta, T):
+    from scipy.stats import nbinom
+    p = theta / (theta + mu)
+    return float(nbinom.sf(T, theta, p))  # P(Y > T)
+
+
+def tail_prob_lognorm(vals, T):
+    from scipy.stats import lognorm
+    v = vals[vals > 0]
+    s, loc, scale = lognorm.fit(v, floc=0.0)
+    return float(lognorm.sf(T, s, loc, scale))
+
+
+def main():
+    parquet, out_json = sys.argv[1], sys.argv[2]
+    df = pd.read_parquet(parquet).reset_index()
+    months = np.sort(df["month_id"].unique())
+    m2i = {m: i for i, m in enumerate(months)}
+    cells = np.sort(df["priogrid_gid"].unique())
+    c2i = {c: i for i, c in enumerate(cells)}
+    sb = np.zeros((len(cells), len(months)))
+    sb[df["priogrid_gid"].map(c2i).values, df["month_id"].map(m2i).values] = df["lr_sb_best"].values
+    absdiff = np.abs(sb - np.roll(sb, 1, 1))
+    recent_vol = np.zeros_like(sb)
+    for t in range(1, sb.shape[1]):
+        lo = max(0, t - 12)
+        recent_vol[:, t] = absdiff[:, lo:t].mean(axis=1)
+
+    y = sb.reshape(-1)
+    pos = y[y > 0]
+    res = {"n_positive": int(pos.size), "max": float(y.max()), "mean_pos": float(pos.mean())}
+
+    # ---- GPD tail index at several thresholds ----
+    res["gpd"] = {}
+    for u in (5, 10, 25, 50):
+        ex = pos[pos > u] - u
+        res["gpd"][f"u={u}"] = gpd_xi(ex)
+    print("GPD tail index xi (heavier tail = larger xi; xi>0.5 => infinite variance):")
+    for k, v in res["gpd"].items():
+        print(f"  {k:7s} n={v['n']:6d} xi={v['xi']}")
+
+    # ---- light-family under-coverage at extreme thresholds ----
+    mu = float(pos.mean())
+    theta = 0.98  # production global theta (S4)
+    res["tail_coverage"] = {}
+    print("\nP(Y>T): empirical vs light families (fit on positives):")
+    for T in (100, 1000, 10000):
+        emp = float(np.mean(pos > T))
+        nb = tail_prob_nb(mu, theta, T)
+        ln = tail_prob_lognorm(pos, T)
+        res["tail_coverage"][f"T={T}"] = {"empirical": emp, "nb_theta0.98": nb, "lognormal": ln,
+                                          "nb_undercover_x": emp / nb if nb > 0 else float("inf"),
+                                          "lognorm_undercover_x": emp / ln if ln > 0 else float("inf")}
+        print(f"  T={T:6d}: emp={emp:.2e}  NB(θ.98)={nb:.2e} ({emp/nb:.0f}x under)  "
+              f"logN={ln:.2e} ({emp/ln:.0f}x under)" if nb > 0 and ln > 0 else
+              f"  T={T:6d}: emp={emp:.2e} NB={nb:.2e} logN={ln:.2e}")
+
+    # ---- is xi state-varying? (tertiles of recent_vol among positive-target cells) ----
+    rv = recent_vol.reshape(-1)[y > 0]
+    res["xi_by_state"] = {}
+    print("\nxi by recent-volatility tertile (state-varying tail heaviness?):")
+    qs = np.quantile(rv, [1 / 3, 2 / 3])
+    for lbl, lo, hi in [("low", -np.inf, qs[0]), ("mid", qs[0], qs[1]), ("high", qs[1], np.inf)]:
+        grp = pos[(rv > lo) & (rv <= hi)]
+        ex = grp[grp > 10] - 10
+        g = gpd_xi(ex)
+        res["xi_by_state"][lbl] = g
+        print(f"  {lbl:4s} n={g['n']:6d} xi={g['xi']}")
+
+    with open(out_json, "w") as fh:
+        json.dump(res, fh, indent=2, default=float)
+    print("\nwrote", out_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/reports/2026-07-29_v2_scoreboard_dossier/tools/activation_metrics.py
+++ b/reports/2026-07-29_v2_scoreboard_dossier/tools/activation_metrics.py
@@ -1,0 +1,74 @@
+"""Activation-aware metrics for the occurrence/magnitude split (#258 — the rollout collapse).
+
+``crps_all`` / MCR go BLIND when the field is ~99% zero: a forecast that almost never fires still
+scores well because the zeros dominate the mean. That blindness is what let the collapse hide
+(views-hydranet#258 — the models under-activate 4–115× yet MCR≈1). These metrics look at the thing
+that actually broke: WHERE and HOW OFTEN the composed forecast says a conflict occurs, and how much
+magnitude it dumps on cells it wrongly fires.
+
+Pure numpy, no torch, no I/O — so the degenerate-forecast red-team can unit-test that they SEE the
+defects (collapse, bloom, imprecise-gate-with-full-magnitude) before they are trusted on cubes.
+
+  * :func:`activation_frequency` — ``P(pred>0)`` vs ``P(truth>0)``: ``act_ratio << 1`` = collapse,
+    ``>> 1`` = bloom. The single number the collapse investigation needed and MCR could not give.
+  * :func:`topk_occurrence` — at the operating point "fire exactly as many cells as truly fire"
+    (top-k by the occurrence score, ``k = #true positives`` — threshold-free):
+      - ``precision_at_k``   : fraction of fired cells that are truly positive (the gate's skill).
+      - ``mag_on_false_pos`` : mean composed magnitude on the FIRED-BUT-ZERO cells — the named #258
+                               risk (truncating the body gives the gate's false positives FULL
+                               magnitude). This is the falsifier ``crps_all`` cannot see.
+      - ``mag_on_true_pos``  : mean composed magnitude on the fired-and-correct cells (contrast).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def activation_frequency(cs: "np.ndarray", truth: "np.ndarray") -> dict:
+    """``P(pred>0)`` (over all cell×sample draws of the composed cube ``cs``) vs ``P(truth>0)``.
+
+    ``act_ratio = act_pred / act_true`` is the collapse/bloom dial: ~1 is calibrated occurrence,
+    ``<< 1`` is the #258 collapse, ``>> 1`` is the self-zeroed/ZINB bloom. ``act_true`` is the base
+    rate; ``nan`` ratio if the truth window has no positives (undefined, not zero)."""
+    cs = np.asarray(cs, dtype=float)
+    truth = np.asarray(truth, dtype=float)
+    act_pred = float((cs > 0).mean()) if cs.size else float("nan")
+    act_true = float((truth > 0).mean()) if truth.size else float("nan")
+    ratio = act_pred / act_true if act_true and act_true > 0 else float("nan")
+    return {"act_pred": act_pred, "act_true": act_true, "act_ratio": ratio}
+
+
+def topk_occurrence(score: "np.ndarray", magnitude: "np.ndarray", truth: "np.ndarray") -> dict:
+    """Fire the top-k cells by ``score`` (``k = #true positives``) and measure precision + the
+    magnitude that lands on the false positives.
+
+    ``score`` — per-cell occurrence signal (the gate probability). ``magnitude`` — per-cell
+    composed mean forecast (``E[y]``). ``truth`` — per-cell truth. Threshold-free: firing exactly
+    ``k`` cells puts precision and false-positive magnitude on the SAME operating point. Ties in
+    ``score`` break deterministically (stable sort) — a constant score therefore scores near the
+    base rate, correctly reporting "no discrimination". ``k = 0`` -> all-``nan``."""
+    score = np.asarray(score, dtype=float)
+    magnitude = np.asarray(magnitude, dtype=float)
+    truth = np.asarray(truth, dtype=float)
+    is_pos = truth > 0
+    k = int(is_pos.sum())
+    if k == 0 or score.size == 0:
+        return {
+            "precision_at_k": float("nan"),
+            "mag_on_false_pos": float("nan"),
+            "mag_on_true_pos": float("nan"),
+            "k": k,
+            "n_false_pos": 0,
+        }
+    fired = np.argsort(score, kind="stable")[::-1][:k]  # the k highest-scoring cells
+    fired_pos = is_pos[fired]
+    fp = fired[~fired_pos]
+    tp = fired[fired_pos]
+    return {
+        "precision_at_k": float(fired_pos.mean()),
+        "mag_on_false_pos": float(magnitude[fp].mean()) if fp.size else 0.0,
+        "mag_on_true_pos": float(magnitude[tp].mean()) if tp.size else float("nan"),
+        "k": k,
+        "n_false_pos": int(fp.size),
+    }

--- a/reports/2026-07-29_v2_scoreboard_dossier/tools/score_v2_horizons.py
+++ b/reports/2026-07-29_v2_scoreboard_dossier/tools/score_v2_horizons.py
@@ -31,7 +31,12 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-_HN = "/home/simon/Documents/scripts/views_platform/views-hydranet"
+# C-247: repo-relative, NEVER a hardcoded machine path (reports/<dossier>/tools/ → 3 up), the
+# pattern proven by gw_stratified.py:128. Kept a `str` so the f-strings below are unchanged.
+# This file carried an absolute /home/... path until 2026-08-15; it survived because the file was
+# untracked, so CI never imported it and the C-247 sweep that fixed the *tests* could not see the
+# *tool* they load. Tracking it made the import fail in CI immediately.
+_HN = str(Path(__file__).resolve().parents[3])
 sys.path.insert(0, str(Path(__file__).resolve().parent))  # own dir (activation_metrics)
 sys.path.insert(0, f"{_HN}/reports/2026-07-17_lodestar_eval_dossier/tools")
 sys.path.insert(0, f"{_HN}/reports/2026-07-25_t0_rollout_skill_dossier/tools")

--- a/reports/2026-07-29_v2_scoreboard_dossier/tools/score_v2_horizons.py
+++ b/reports/2026-07-29_v2_scoreboard_dossier/tools/score_v2_horizons.py
@@ -1,0 +1,201 @@
+"""V2 HORIZON SCOREBOARD RULER — the frozen rollout ruler, on datafactory v2 truth, + MCR columns.
+
+Dossier 2026-07-29_v2_scoreboard. This is a **versioned** scorer: it does NOT mutate the frozen
+lodestar T=0 tool (2026-07-17) nor the closed rollout ruler (2026-07-25). It REUSES both verbatim:
+the frozen metric primitives (crps_ensemble, average_precision, brier, apply_threshold_gate,
+_resolve_thresh) and the rollout ruler gather/support/truth machinery (gather_all_horizons,
+`_support_keys`, `_truth_map`, `_persistence_gathered`). The ONLY thing re-implemented here is the
+per-(model,target,h) scoring loop, so that two Magnitude-Calibration-Ratio columns can be emitted
+beside the existing ones:
+
+  * ``pos_mcr``  — mean(E[y]/truth) over EVENT cells  (= mcr_events; already in the frozen tools)
+  * ``mcr_all``  — mean(pred)/mean(true) over ALL cells   (the repo/glossary canonical MCR)
+  * ``mcr_none`` — mean(pred) over TRUE-ZERO cells   (leaked mass, count space; the bloom signal;
+        the ratio is division-by-zero on zero cells, so we report the absolute mass)
+
+Default truth = the frozen v2 datafactory truth (`v2_ruler.V2_TRUTH`); default horizons = h=1/18/36
+(first / middle / last forecast month). h=1 byte-reproduces the frozen lodestar T=0 (the anchor,
+tested in `tests/test_score_v2_horizons.py`).
+
+CLI:
+  score_v2_horizons.py "<label>|<pred_dir>|lr_{t}_best|by_{t}_best[|thresh]" ... \
+      [--targets sb,ns,os] [--horizons 1,18,36] [--persistence] [--truth <parquet>] [--out csv]
+  (omit <truth> to use the frozen v2 datafactory truth)
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+_HN = "/home/simon/Documents/scripts/views_platform/views-hydranet"
+sys.path.insert(0, str(Path(__file__).resolve().parent))  # own dir (activation_metrics)
+sys.path.insert(0, f"{_HN}/reports/2026-07-17_lodestar_eval_dossier/tools")
+sys.path.insert(0, f"{_HN}/reports/2026-07-25_t0_rollout_skill_dossier/tools")
+sys.path.insert(0, f"{_HN}/reports/2026-07-28_datafactory_migration_dossier/tools")
+
+from activation_metrics import activation_frequency, topk_occurrence  # noqa: E402
+from lodestar_score import (  # noqa: E402
+    _resolve_thresh,
+    apply_threshold_gate,
+    average_precision,
+    brier,
+    crps_ensemble,
+)
+from rollout_skill_score import (  # noqa: E402
+    _persistence_gathered,
+    _support_keys,
+    _truth_map,
+    gather_all_horizons,
+)
+
+try:
+    from v2_ruler import V2_TRUTH  # noqa: E402  frozen datafactory truth path
+except Exception:  # pragma: no cover - v2_ruler import is a convenience default only
+    V2_TRUTH = Path(
+        f"{_HN}/reports/2026-07-28_datafactory_migration_dossier/tools/v2_truth"
+        "/calibration_datafactory_df.parquet"
+    )
+
+DEFAULT_HORIZONS = (1, 18, 36)  # first / middle / last forecast month
+
+
+def _metric_row(label, g, support, tmap, tgt, h, thr):
+    """Score one (model, target, horizon). Mirrors the frozen rollout ruler metric block,
+    then adds mcr_all + mcr_none. g = gathered dict (origin_m0, h, unit) -> (cs, gate)."""
+    cs = np.stack([g[(m0, h, u)][0] for (m0, u) in support])  # (N, S)
+    has_gate = g[(support[0][0], h, support[0][1])][1] is not None
+    p = (
+        np.array([g[(m0, h, u)][1] for (m0, u) in support])
+        if has_gate
+        else (cs > 0).mean(1)
+    )
+    if thr is not None:
+        if not has_gate:
+            raise ValueError(f"[{tgt}] {label}: th_gated needs a gate — FAIL")
+        cs = apply_threshold_gate(cs, p, thr)  # body-only; p (AP/Brier) unchanged
+    truth = np.array([tmap[(m0 + h - 1, u)] for (m0, u) in support], dtype=float)
+    ev = truth > 0
+    ze = ~ev
+    c = crps_ensemble(truth, cs)
+    ey = cs.mean(1)
+    ratio = ey[ev] / truth[ev] if ev.sum() else np.array([])
+    tmean = float(truth.mean())
+    # #258 activation-aware metrics (crps_all/MCR are blind to the collapse): occurrence frequency,
+    # gate precision@k, and the named risk — composed magnitude on the gate's false positives.
+    af = activation_frequency(cs, truth)
+    tk = topk_occurrence(p, ey, truth)  # rank by the gate p; magnitude = composed mean ey
+    return dict(
+        target=tgt,
+        model=label,
+        h=h,
+        N=len(support),
+        n_event=int(ev.sum()),
+        AP=average_precision((truth > 0).astype(float), p),
+        Brier=brier((truth > 0).astype(float), p),
+        crps_all=float(c.mean()),
+        crps_events=float(c[ev].mean()) if ev.sum() else float("nan"),
+        crps_none=float(c[ze].mean()) if ze.sum() else float("nan"),
+        size_ratio=float(np.median(ratio)) if ratio.size else float("nan"),
+        pos_mcr=float(np.mean(ratio)) if ratio.size else float("nan"),  # = mcr_events
+        mcr_all=float(ey.mean() / tmean) if tmean > 0 else float("nan"),
+        mcr_none=float(ey[ze].mean()) if ze.sum() else float("nan"),  # leaked mass (count space)
+        act_pred=af["act_pred"],  # P(pred>0): the composed activation frequency
+        act_true=af["act_true"],  # P(truth>0): the base rate
+        act_ratio=af["act_ratio"],  # <<1 = #258 collapse, >>1 = bloom, ~1 = calibrated occurrence
+        precision_at_k=tk["precision_at_k"],  # gate skill at "fire k = #true positives"
+        mag_on_false_pos=tk["mag_on_false_pos"],  # THE #258 risk: magnitude on gate false-pos
+        mag_on_true_pos=tk["mag_on_true_pos"],  # magnitude on correctly-fired cells (contrast)
+        n_false_pos=tk["n_false_pos"],
+        gate_source=("gate-head" if has_gate else "frac(samples>0)"),
+    )
+
+
+def score_horizons_v2(
+    registry,
+    targets=("sb", "ns", "os"),
+    horizons=DEFAULT_HORIZONS,
+    truth_parquet=str(V2_TRUTH),
+    add_persistence=False,
+):
+    """registry: list of (label, pred_dir, lr_tmpl, by_tmpl_or_None[, thresh_spec]). One row per
+    model×target×horizon, with the frozen metric set + mcr_all + mcr_none. Identical (origin,cell)
+    support intersected across all arms at every scored horizon (G4)."""
+    horizons = tuple(horizons)
+    thresh_by_label = {e[0]: (e[4] if len(e) > 4 else None) for e in registry}
+    rows = []
+    for tgt in targets:
+        lr_full = "lr_" + tgt + "_best"
+        support = sorted(
+            set.intersection(
+                *[_support_keys(e[1], e[2].format(t=tgt), horizons) for e in registry]
+            )
+        )
+        if not support:
+            raise ValueError(f"[{tgt}] EMPTY fixed support across models/horizons — FAIL")
+        months = {m0 + h - 1 for (m0, _u) in support for h in horizons}
+        tmap = _truth_map(truth_parquet, lr_full, months)
+        for entry in list(registry):
+            label, pdir, lr_tmpl, by_tmpl = entry[0], entry[1], entry[2], entry[3]
+            g = gather_all_horizons(
+                pdir, lr_tmpl.format(t=tgt), by_tmpl.format(t=tgt) if by_tmpl else None
+            )
+            thr = _resolve_thresh(thresh_by_label.get(label), tgt)
+            for h in horizons:
+                rows.append(_metric_row(label, g, support, tmap, tgt, h, thr))
+            del g  # free this arm's cubes before the next (OOM guard)
+        if add_persistence:
+            gp = _persistence_gathered(tmap, support, horizons)
+            for h in horizons:
+                rows.append(_metric_row("persistence", gp, support, tmap, tgt, h, None))
+    return rows
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    targets = ["sb", "ns", "os"]
+    horizons = DEFAULT_HORIZONS
+    truth = str(V2_TRUTH)
+    add_persistence = False
+    out_csv = "v2_scoreboard.csv"
+    entries = []
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a.startswith("--targets"):
+            targets = a.split("=", 1)[1].split(",")
+        elif a.startswith("--horizons"):
+            horizons = tuple(int(x) for x in a.split("=", 1)[1].split(","))
+        elif a == "--persistence":
+            add_persistence = True
+        elif a.startswith("--truth"):
+            truth = a.split("=", 1)[1]
+        elif a.startswith("--out"):
+            out_csv = a.split("=", 1)[1]
+        else:
+            parts = a.split("|")
+            entries.append(
+                (
+                    parts[0],
+                    parts[1],
+                    parts[2],
+                    parts[3] if len(parts) > 3 and parts[3] else None,
+                    parts[4] if len(parts) > 4 and parts[4] else None,
+                )
+            )
+        i += 1
+    rows = score_horizons_v2(
+        entries, targets, horizons=horizons, truth_parquet=truth, add_persistence=add_persistence
+    )
+    df = pd.DataFrame(rows)
+    df.to_csv(out_csv, index=False)
+    print(f"wrote {out_csv}  ({len(df)} rows: {df.model.nunique()} models × "
+          f"{len(targets)} targets × {len(horizons)} h)")
+    for tgt in targets:
+        sub = df[df.target == tgt]
+        print(f"\n=== {tgt}: crps_all / mcr_none by horizon ===")
+        print(sub.pivot_table(index="model", columns="h", values="crps_all")
+              .to_string(float_format=lambda x: f"{x:.4f}"))

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -5,12 +5,12 @@
 | Project           | views-hydranet                       |
 | Owner             | Simon Polichinel von der Maase       |
 | Last Updated      | 2026-08-15                           |
-| ID accounting     | C-188 merged into C-182 on 2026-08-15; C-275/C-276 added the same day; C-284..C-287 added 2026-08-15 from PR #274's `/code-review max`. `C-34`/`C-188` are intentional numbering gaps (merged entries). |
+| ID accounting     | C-188 merged into C-182 on 2026-08-15; C-275/C-276 added the same day; C-284..C-287 added 2026-08-15 from PR #274's `/code-review max`; C-260 relocated → §Resolved 2026-08-15 (fix verified in source + test). `C-34`/`C-188` are intentional numbering gaps (merged entries). |
 | Total Concerns    | 284                                  |
-| Open Concerns     | 133                                  |
+| Open Concerns     | 132                                  |
 | — of which demoted (tech-debt) | 13 (tagged `[DEMOTED]` in §Open Concerns; indexed in §Tech-Debt Backlog) |
-| — net active risks | 120                                 |
-| Resolved Concerns | 151                                  |
+| — net active risks | 119                                 |
+| Resolved Concerns | 152                                  |
 | Last curation pass | **2026-08-15 (review-rr strategic).** 24 entries relocated §Open → §Resolved: the 12 PR-#216 bannered entries (C-138/234/235/236/237/238/239/240/241/242/243/247) whose relocation this header had flagged as pending, plus 12 whose fixes were verified in source but never recorded (C-132/146/179/180/193/194/195/196/197/201/251 + C-184, the last with residual C-273). C-188 merged into C-182; C-134 re-tiered 2→3; 7 Tier-4 entries demoted; 2 causal clusters added (14 positional coupling, 15 register↔code sync). Open 145 → 120, then → 122 with 2 blind-spot entries registered the same day (C-275 data vintage, C-276 forecast monitoring). |
 
 ---
@@ -1895,21 +1895,6 @@ Three low-severity items from the prioritized dev→main release review; **none 
 
 ---
 
-### C-260: scheduled-sampling channel substitution assumes features == regression_targets in ORDER (set-based warning misses it)
-
-| Field | Value |
-|-------|-------|
-| ID | C-260 |
-| Tier | 2 |
-| Source | expert-code-review (2026-08-14, ADR-056 scheduled-sampling pre-run correctness review) |
-| Trigger | Setting `ss_epsilon_max > 0` with a config whose `features` and `regression_targets` are the same length but a DIFFERENT order (e.g. reordering targets, or adding a dynamic covariate so the lists diverge) |
-| Location | `views_hydranet/train/training_engine.py:329-334` (`t0_gt = t0[:, idx.feat]`; `torch.where(mask, prev_pred[:n_reg], t0_gt)`); `views_hydranet/utils/config_initializer.py:322-346` (`validate_laws` — set-based `logger.warning` only) |
-| Cross-refs | C-98, C-105 (the count constraint, both marked RESOLVED via the set-based warning), C-259 (same SS-enablement trigger) |
-
-The scheduled-sampling substitution replaces `t0_gt` (the `idx.feat` input channels) with `prev_pred` (the `n_reg` target forecasts) via `torch.where`. This assumes `features == regression_targets` in **count AND order**. `validate_laws` only `logger.warning`s on `set(features) != set(regression_targets)` (the "resolution" for C-98/C-105) — a **set** check that (a) never raises and (b) **passes same-length-different-order**, which would silently feed the `sb`-forecast into the `ns`-input channel (cross-target corruption). For the current conflict-only configs (`features == regression_targets`, same order) it is benign; enabling `ss_epsilon_max>0` on any reordered/extended config makes it a live silent corruption. **Tier 2 (silent model-input corruption under a realistic non-default config; clear trigger).** Fix direction: order-strict `list(features) == list(regression_targets)` **raise** when `ss_epsilon_max>0`.
-
----
-
 ### C-261: scheduled-sampling training feedback draw uses generator=None (global RNG) → non-reproducible; blocks byte-exact parity
 
 | Field | Value |
@@ -2554,6 +2539,25 @@ Demoted per the three-track model: Tier-4, mechanical-or-standing, single-file/s
 ## Resolved Concerns
 
 <!-- 2026-07-27 register tidy (review-rr strategic): the entries below were resolved-in-place in §Open and physically relocated here. -->
+
+### C-260: scheduled-sampling channel substitution assumes features == regression_targets in ORDER (set-based warning misses it) — RESOLVED
+
+| Field | Value |
+|-------|-------|
+| ID | C-260 |
+| Tier | 2 |
+| Source | expert-code-review (2026-08-14, ADR-056 scheduled-sampling pre-run correctness review) |
+| Trigger | Setting `ss_epsilon_max > 0` with a config whose `features` and `regression_targets` are the same length but a DIFFERENT order (e.g. reordering targets, or adding a dynamic covariate so the lists diverge) |
+| Location | `views_hydranet/train/training_engine.py:329-334` (`t0_gt = t0[:, idx.feat]`; `torch.where(mask, prev_pred[:n_reg], t0_gt)`); `views_hydranet/utils/config_initializer.py:322-346` (`validate_laws` — set-based `logger.warning` only) |
+| Cross-refs | C-98, C-105 (the count constraint, both marked RESOLVED via the set-based warning), C-259 (same SS-enablement trigger) |
+
+The scheduled-sampling substitution replaces `t0_gt` (the `idx.feat` input channels) with `prev_pred` (the `n_reg` target forecasts) via `torch.where`. This assumes `features == regression_targets` in **count AND order**. `validate_laws` only `logger.warning`s on `set(features) != set(regression_targets)` (the "resolution" for C-98/C-105) — a **set** check that (a) never raises and (b) **passes same-length-different-order**, which would silently feed the `sb`-forecast into the `ns`-input channel (cross-target corruption). For the current conflict-only configs (`features == regression_targets`, same order) it is benign; enabling `ss_epsilon_max>0` on any reordered/extended config makes it a live silent corruption. **Tier 2 (silent model-input corruption under a realistic non-default config; clear trigger).** Fix direction: order-strict `list(features) == list(regression_targets)` **raise** when `ss_epsilon_max>0`.
+
+**RESOLVED (verified 2026-08-15).** The fix direction named above landed: `config_initializer.py:1090-1097` raises when scheduled sampling is active and `list(features) != list(regression_targets)`, with the `C-260` marker in the message, and `tests/test_scheduled_sampling.py:264` asserts `pytest.raises(ValueError, match="C-260")`. The set-based `validate_laws` warning is unchanged and still only a warning — it is no longer load-bearing, because the order-strict raise fires first whenever the substitution can run.
+
+**Its three siblings stay OPEN and were re-verified in the same pass:** C-259 is mitigated by rejection, not fixed (the gated-mean training feedback is marked a deferred fix in source); C-261 is open on its own terms — `training_engine.py:228-229` states that the production call site passes `generator=None`, so SS training feedback is not byte-reproducible and only the parity test exercises the seeded path; C-262 is open — only `test_epsilon_zero_produces_finite_loss` exists, with no byte-identical pin.
+
+---
 
 ### C-197: distribution registry / legacy `output_distribution` name collision → silent legacy hijack — RESOLVED
 

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -5,11 +5,11 @@
 | Project           | views-hydranet                       |
 | Owner             | Simon Polichinel von der Maase       |
 | Last Updated      | 2026-08-15                           |
-| ID accounting     | C-188 merged into C-182 on 2026-08-15; C-275/C-276 added the same day; C-284..C-287 added 2026-08-15 from PR #274's `/code-review max`; C-260 relocated → §Resolved 2026-08-15 (fix verified in source + test). `C-34`/`C-188` are intentional numbering gaps (merged entries). |
-| Total Concerns    | 284                                  |
-| Open Concerns     | 132                                  |
+| ID accounting     | C-188 merged into C-182 on 2026-08-15; C-275/C-276 added the same day; C-284..C-287 added 2026-08-15 from PR #274's `/code-review max`; C-260 relocated → §Resolved 2026-08-15 (fix verified in source + test); C-288 added 2026-08-15 from PR #276's CI failure. `C-34`/`C-188` are intentional numbering gaps (merged entries). |
+| Total Concerns    | 285                                  |
+| Open Concerns     | 133                                  |
 | — of which demoted (tech-debt) | 13 (tagged `[DEMOTED]` in §Open Concerns; indexed in §Tech-Debt Backlog) |
-| — net active risks | 119                                 |
+| — net active risks | 120                                 |
 | Resolved Concerns | 152                                  |
 | Last curation pass | **2026-08-15 (review-rr strategic).** 24 entries relocated §Open → §Resolved: the 12 PR-#216 bannered entries (C-138/234/235/236/237/238/239/240/241/242/243/247) whose relocation this header had flagged as pending, plus 12 whose fixes were verified in source but never recorded (C-132/146/179/180/193/194/195/196/197/201/251 + C-184, the last with residual C-273). C-188 merged into C-182; C-134 re-tiered 2→3; 7 Tier-4 entries demoted; 2 causal clusters added (14 positional coupling, 15 register↔code sync). Open 145 → 120, then → 122 with 2 blind-spot entries registered the same day (C-275 data vintage, C-276 forecast monitoring). |
 
@@ -2340,6 +2340,24 @@ Tier 4: no wrong number today, and the raises do the real work. It is on record 
 | Cross-refs | C-218 (the invariant), C-286 (the same file's audit-record weaknesses) |
 
 The flag exists so a broken-by-construction rollout can be scored as a **labelled diagnostic** rather than as deployed skill. Applied run-globally it suspends that gate for *every* arm in the batch, so a second arm that unexpectedly carries `rollout_feedback='mean'` passes silently and is recorded `diagnostic_only: true` — a true record of a decision nobody made about it. The gate should be opted out of per arm, e.g. `arm=dir:diagnostic`.
+
+---
+### C-288: seven tracked `reports/` tools still hardcode `/home/simon/...`; C-247's sweep fixed the tests, not the tools they load
+
+| Field | Value |
+|-------|-------|
+| ID | C-288 |
+| Tier | 3 |
+| Source | PR #276 CI failure (2026-08-15) — tracking `score_v2_horizons.py` made it import in CI, which failed instantly on its absolute path |
+| Trigger | Force-tracking any further `reports/**/tools/*.py`, or running one of the seven below on any machine but this one (CI, a colleague's clone, the server) — the import or the artifact read fails, or silently reads nothing |
+| Location | `2026-07-17_densemse_mechanics_grid/tools/insample_probe.py:17,23,29`; `2026-07-25_t0_rollout_skill_dossier/tools/rollout_skill_score.py:32`, `s6_score_one.py:24,27`, `s7_verdict.py:20`; `2026-08-08_hydranet_ensemble_dossier/tools/s2_df_freshness_check.py:14` |
+| Cross-refs | C-247 (same defect, resolved for the *test* files only), F4-07 / `test_P5a_no_tracked_test_hardcodes_absolute_machine_path` (the two guards that each cover half of this) |
+
+C-247 is marked RESOLVED and its fix was real — but it covered `tests/test_score_v2_horizons.py` and its sibling, **not the dossier tool they load**. `score_v2_horizons.py` kept `_HN = "/home/simon/..."` and nothing caught it, because the file was untracked: CI never imported it, and `test_P5a_no_tracked_test_hardcodes_absolute_machine_path` only scans `tests/*.py`. Tracking it in PR #276 surfaced the defect in one CI run (`ModuleNotFoundError: No module named 'lodestar_score'`) and it was fixed there with the repo's own `Path(__file__).resolve().parents[3]` pattern.
+
+**Seven tracked tools still carry the same hardcoded prefix.** None breaks CI today: no test imports them, and `rollout_skill_score.py:32`'s insert is a harmless no-op because whatever imports it has already put the lodestar directory on `sys.path`. That is luck, not design — `rollout_skill_score.py` is on the live import chain of both the v2 scoreboard and the Epic #263 ruler, so a change in import order turns it into a failure.
+
+**Not fixed in PR #276, deliberately.** Four of the seven are frozen scorers that Epic #263's `SCOPE.md` explicitly ring-fences; sweeping them is a separate, reviewable change rather than collateral work on a PR about tracking. **Fix direction:** replace each with `Path(__file__).resolve().parents[3]`, then widen `test_P5a` (or F4-07) from `tests/*.py` to every tracked `.py`, which makes the guard match the concern.
 
 ---
 

--- a/tests/test_activation_metrics.py
+++ b/tests/test_activation_metrics.py
@@ -5,7 +5,11 @@ blind to. So each test feeds a hand-built DEGENERATE forecast and asserts the me
 stays silent) as it must: collapse, bloom, a perfect oracle, and — the crucial one — the named #258
 risk (an imprecise gate whose false positives receive FULL magnitude once the body is truncated).
 
-Tool lives under the gitignored ``reports/`` tree, so skip cleanly where it is absent (C-247).
+The tool is **force-tracked** (``git add -f``), so these tests run in CI. They did not until
+2026-08-15: ``reports/`` is gitignored and ``activation_metrics.py`` had never been added, so the
+whole module skipped in every clean clone — the readout for the #258 rollout-gate programme with
+none of its red-team coverage running. The guard below survives only for a genuinely sparse
+checkout; ``test_falsification_repo_clean`` now pins the tracking so it cannot silently return.
 """
 
 from __future__ import annotations
@@ -21,7 +25,8 @@ _TOOL = _HN / "reports/2026-07-29_v2_scoreboard_dossier/tools/activation_metrics
 
 if not _TOOL.exists():
     pytest.skip(
-        "activation_metrics is a gitignored dossier tool (absent in a clone/CI); C-247.",
+        "activation_metrics.py is absent — it is force-tracked, so this means a sparse or "
+        "partial checkout, not a normal clone (C-247).",
         allow_module_level=True,
     )
 

--- a/tests/test_falsification_repo_clean.py
+++ b/tests/test_falsification_repo_clean.py
@@ -7,6 +7,7 @@ Each test below encodes a specific falsifying observation. Tests are RED
 stubs — they FAIL to document the gap. When the gap is fixed, flip to GREEN.
 """
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -166,4 +167,75 @@ class TestF4_06_DoubleSeparators:
 
         assert len(doubles) == 0, (
             f"SOFT FALSIFICATION F4-06: {len(doubles)} double separator(s) at line(s) {doubles}"
+        )
+
+
+# ── F4-07: HARD — Tracked code depending on untracked `reports/` files ───────
+
+
+class TestF4_07_UntrackedDependencies:
+    """A tracked test or tool must never depend on a file that is not in the repository.
+
+    `reports/` is gitignored, but the scorers under it are force-tracked (`git add -f`) so their
+    tests run in CI. When one is missed, nothing goes red: the dependent test carries a
+    `pytest.skip(allow_module_level=True)` guard and silently reports success while measuring
+    nothing. That has now happened three times — the Epic #263 ruler shipped with zero portable
+    coverage, and `activation_metrics.py` / `score_v2_horizons.py` were both unreachable from a
+    clean clone while their tests "passed". The second of those is loaded at runtime by
+    `rescore_v2.py`, a tracked driver, so the shipped ruler could not run in a fresh checkout.
+
+    The rule is derived, not listed, so a new dependency is covered without anyone remembering to
+    add it here. A prose reference counts as a dependency too: `tail_index.py` cites
+    `s5_tail.py::gpd_xi` as the remedy for C-284, which is a dead pointer for every reader but the
+    author if the file is not in the repo.
+
+    **Known limit:** it can only flag a file that exists on the machine running it, so it catches
+    the mistake where it is made (authoring) rather than in CI, where an untracked file is simply
+    absent and indistinguishable from one that was never there.
+    """
+
+    @staticmethod
+    def _tracked(root: Path) -> set:
+        out = subprocess.run(
+            ["git", "ls-files"], capture_output=True, text=True, cwd=root, check=True
+        )
+        return set(out.stdout.split())
+
+    @staticmethod
+    def _referenced_report_paths(text: str) -> set:
+        """Literal `reports/.../x.py` paths appearing in a source file."""
+        return set(re.findall(r"reports/[\w./-]+?\.py", text))
+
+    def test_no_tracked_file_depends_on_an_untracked_report_tool(self):
+        """F4-07: every `reports/*.py` reachable from tracked code must itself be tracked."""
+        root = Path(__file__).parent.parent
+        tracked = self._tracked(root)
+        missing = []
+
+        # 1. Tracked tests / scripts naming a dossier tool by path.
+        for rel in sorted(tracked):
+            if not rel.endswith(".py") or not (
+                rel.startswith("tests/") or rel.startswith("scripts/")
+            ):
+                continue
+            for dep in self._referenced_report_paths((root / rel).read_text()):
+                if dep not in tracked and (root / dep).exists():
+                    missing.append(f"{rel} -> {dep}")
+
+        # 2. Tracked dossier tools importing a sibling module from their own `tools/` dir.
+        for rel in sorted(t for t in tracked if "/tools/" in t and t.endswith(".py")):
+            src = (root / rel).read_text()
+            tools_dir = Path(rel).parent
+            for dep in self._referenced_report_paths(src):
+                if dep not in tracked and (root / dep).exists():
+                    missing.append(f"{rel} -> {dep}")
+            for mod in re.findall(r"^\s*from\s+(\w+)\s+import\s", src, re.M):
+                sibling = str(tools_dir / f"{mod}.py")
+                if (root / sibling).exists() and sibling not in tracked:
+                    missing.append(f"{rel} -> {sibling} (sibling import)")
+
+        assert not missing, (
+            "HARD FALSIFICATION F4-07: tracked code depends on untracked `reports/` file(s). "
+            "Their guard tests will skip in CI and report success while measuring nothing. "
+            "Fix with `git add -f <path>`.\n  " + "\n  ".join(sorted(set(missing)))
         )

--- a/tests/test_falsification_repo_clean.py
+++ b/tests/test_falsification_repo_clean.py
@@ -212,27 +212,26 @@ class TestF4_07_UntrackedDependencies:
         tracked = self._tracked(root)
         missing = []
 
-        # 1. Tracked tests / scripts naming a dossier tool by path.
-        for rel in sorted(tracked):
-            if not rel.endswith(".py") or not (
-                rel.startswith("tests/") or rel.startswith("scripts/")
-            ):
-                continue
-            for dep in self._referenced_report_paths((root / rel).read_text()):
-                if dep not in tracked and (root / dep).exists():
-                    missing.append(f"{rel} -> {dep}")
-
-        # 2. Tracked dossier tools importing a sibling module from their own `tools/` dir.
-        for rel in sorted(t for t in tracked if "/tools/" in t and t.endswith(".py")):
+        depends_on_reports = [
+            rel
+            for rel in sorted(tracked)
+            if rel.endswith(".py") and (rel.startswith(("tests/", "scripts/")) or "/tools/" in rel)
+        ]
+        for rel in depends_on_reports:
             src = (root / rel).read_text()
-            tools_dir = Path(rel).parent
+
+            # A dossier tool named by path — how tests and drivers reach one.
             for dep in self._referenced_report_paths(src):
                 if dep not in tracked and (root / dep).exists():
                     missing.append(f"{rel} -> {dep}")
-            for mod in re.findall(r"^\s*from\s+(\w+)\s+import\s", src, re.M):
-                sibling = str(tools_dir / f"{mod}.py")
-                if (root / sibling).exists() and sibling not in tracked:
-                    missing.append(f"{rel} -> {sibling} (sibling import)")
+
+            # A tool importing a sibling from its own `tools/` dir after a sys.path insert —
+            # a plain `from x import y`, so the path form above cannot see it.
+            if "/tools/" in rel:
+                for mod in re.findall(r"^\s*from\s+(\w+)\s+import\s", src, re.M):
+                    sibling = str(Path(rel).parent / f"{mod}.py")
+                    if (root / sibling).exists() and sibling not in tracked:
+                        missing.append(f"{rel} -> {sibling} (sibling import)")
 
         assert not missing, (
             "HARD FALSIFICATION F4-07: tracked code depends on untracked `reports/` file(s). "

--- a/tests/test_score_v2_horizons.py
+++ b/tests/test_score_v2_horizons.py
@@ -18,16 +18,18 @@ import pandas as pd
 import pytest
 
 # C-247/F-Z2: repo-relative (tests/ is one level below the repo root) — NEVER a hardcoded machine
-# path. The scorer + lodestar tools live under the gitignored `reports/` dossier tree, so they are
-# absent in a fresh clone / CI; skip this module cleanly there rather than erroring (false-green).
+# path. `reports/` is gitignored, but both tools below are **force-tracked** (`git add -f`), so a
+# normal clone has them and this module runs in CI. `score_v2_horizons.py` was NOT tracked until
+# 2026-08-15, which silently skipped this module everywhere and left `rescore_v2.py` — a tracked
+# driver that loads it at runtime — unable to run in a clean clone at all.
 _HN = Path(__file__).resolve().parents[1]
 _LODE_DIR = _HN / "reports/2026-07-17_lodestar_eval_dossier/tools"
 _V2_TOOL = _HN / "reports/2026-07-29_v2_scoreboard_dossier/tools/score_v2_horizons.py"
 
 if not _V2_TOOL.exists() or not (_LODE_DIR / "lodestar_score.py").exists():
     pytest.skip(
-        "v2 scoreboard dossier tools are gitignored (absent in a clone/CI); this test scores "
-        "research-dossier tooling and runs only where reports/ exists (C-247).",
+        "v2 scoreboard / lodestar tools are absent — both are force-tracked, so this means a "
+        "sparse or partial checkout, not a normal clone (C-247).",
         allow_module_level=True,
     )
 


### PR DESCRIPTION
Enabling work for the #258/#262 rollout-gate programme. **The readout those experiments are read through was not in the repository.**

## What was wrong

`reports/` is gitignored but 437 files under it are force-tracked with `git add -f`. Three were missed, and each is reachable from tracked code:

| file | reached by | consequence |
|---|---|---|
| `activation_metrics.py` | `tests/test_activation_metrics.py`; imported by `score_v2_horizons.py` | its **8 red-team tests skipped in every clean clone** — the tests that prove the metric *sees* collapse, bloom, and the #258 failure (an imprecise gate whose false positives receive full magnitude once the body is truncated) |
| `score_v2_horizons.py` | `tests/test_score_v2_horizons.py`; loaded at runtime by `rescore_v2.py` | tests skipped, **and the Epic #263 ruler merged yesterday could not run in a fresh checkout** |
| `s5_tail.py` | cited by `tail_index.py` as the `gpd_xi` remedy for **C-284** | a dead pointer for any reader without this machine's disk |

**Nothing went red for any of it.** The dependent tests carry `pytest.skip(allow_module_level=True)` guards, so they reported success while measuring nothing. This is the same class Epic #263 found — the ruler gating ship decisions had zero portable coverage — one layer up.

## Changes

- **`git add -f` the three files, in place.** No moves. Five sibling scorers (`lodestar_score`, `rollout_skill_score`, `gw_stratified`, `v2_ruler`, `foundation_gated_nb`) are already tracked under their dossiers; this matches the established home rather than inventing a new one. Their remaining imports were already tracked, so the dependency graph closes.
- **Corrected two false skip messages** claiming the tools are *"gitignored (absent in a clone/CI)"* — untrue once tracked. The guards stay as a genuine safety net for a sparse checkout.
- **New falsifier `F4-07`** in the existing `tests/test_falsification_repo_clean.py`: for tracked tests/scripts and tracked dossier tools, resolve literal `reports/*.py` paths and sibling-module imports, and assert each is tracked. Derived, not a hand-maintained list. **Verified red on the pre-fix state** (it names both `activation_metrics.py` edges) **and green after** — a guard that cannot fail is not a guard.
- **C-260 → §Resolved.** The order-strict validator raises at `config_initializer.py:1090-1097` carrying the `C-260` marker, and `tests/test_scheduled_sampling.py:264` asserts `pytest.raises(ValueError, match="C-260")`.

## Corrections to my own earlier claims

I told the maintainer four things blocked experimenting. Investigation dissolved three:

- **"The register is wrong about scheduled sampling"** — it is not, and I was. Re-verified each: **C-261 is genuinely open** (`training_engine.py:228-229` states in its own docstring that the production call site passes `generator=None`, so SS training feedback is not byte-reproducible; only the parity test exercises the seeded path). **C-262 is genuinely open** (only `test_epsilon_zero_produces_finite_loss` exists). **C-259 is mitigated by rejection, not fixed** (gated-mean training feedback is marked a deferred fix in source). Only C-260 was resolvable. I had read grep hits as fixes.
- **"ADR-058 does not exist"** — true, but not a defect. The absence is recorded in `ADR-027:56` ("no ADR-058 file was written; the direction is parked"), in `docs/CICs/TrainingEngine.md`, and guarded by `reject_unwired_rollout_horizon`, which **raises** on `rollout_horizon != 1` and is pinned by a test. Nothing is silently broken. **No action.**
- **"The 40-lesson / seed-42 / one-origin-set caveat needs recording"** — already written down in issue #262 under *Caveat (honest scoping)*. A second copy is a second thing to maintain. **No action.**

## Verification

- `git ls-files` lists all four v2-scoreboard tools and `s5_tail.py`
- `mv reports reports.off` → both modules **skip** (2 skipped); restored → **10 pass**. The guard still protects a sparse checkout; a normal clone now runs the tests.
- F4-07 confirmed red on the pre-fix state, green after
- `ruff check` / `ruff format --check` clean
- **1409 passed**, 12 skipped, 13 xfailed (+1 vs `development`: the new falsifier). The gain is in CI, where 10 previously-skipping tests now run.

## Out of scope

The gate experiment design; the body / `truncated_nb`; promoting any scorer to `scripts/`; writing ADR-058; C-259/C-261/C-262 (correctly Open — C-261 is a real determinism gap that matters only if scheduled sampling is revived, and it is already falsified as a rollout fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)