### PR TITLE
Load the persistence baseline's history month in both scorers — closes #282

### DIFF
--- a/reports/2026-07-25_t0_rollout_skill_dossier/tools/rollout_skill_score.py
+++ b/reports/2026-07-25_t0_rollout_skill_dossier/tools/rollout_skill_score.py
@@ -105,8 +105,29 @@ def _truth_map(truth_parquet: str, lr_full: str, months: set):
     return tm
 
 
-def _persistence_gathered(truth_map, support, horizons=HORIZONS):
-    """Persistence 'model': feed the last OBSERVED value truth[m0-1] as a 1-sample forecast at every h."""
+def _persistence_gathered(truth_map, support, horizons=HORIZONS, months_loaded=None):
+    """Persistence 'model': feed truth[m0-1] as a 1-sample forecast at every h.
+
+    **GH #282.** `truth_map` is built from the SCORED months `{m0+h-1}`, which do not include the
+    history month `m0-1`. It is present only *by accident* — origins are usually consecutive, so
+    origin k's history is origin k-1's h=1 forecast month — and the FIRST origin has no such
+    neighbour. Its history therefore fell through `.get(..., 0.0)` and its entire persistence
+    forecast became zeros, silently understating the baseline by 4-10% at 13 origins and by
+    everything at one.
+
+    A missing **cell** inside a loaded month is a legitimate 0.0 (`_truth_map` builds a dense
+    per-month dict). A missing **month** is not a measurement at all. Pass `months_loaded` to keep
+    them distinguishable; callers in this repo do. Left optional rather than required so that
+    archived analyses that reconstruct this call still run — but they run WRONG, which is why every
+    live caller passes it.
+    """
+    if months_loaded is not None:
+        missing = sorted({m0 - 1 for (m0, _u) in support} - set(months_loaded))
+        if missing:
+            raise ValueError(
+                f"persistence needs history months {missing}, which were never loaded — "
+                f"refusing to score them as zeros (GH #282)"
+            )
     out = {}
     for (m0, u) in support:
         last = truth_map.get((m0 - 1, u), 0.0)  # last observed month before T=0
@@ -130,7 +151,9 @@ def score_horizons(truth_parquet, registry, targets, horizons=HORIZONS, add_pers
         )
         if not support:
             raise ValueError(f"[{tgt}] EMPTY fixed support across models/horizons — FAIL")
+        # history months included for the persistence baseline — see GH #282
         months = {m0 + h - 1 for (m0, _u) in support for h in horizons}
+        months |= {m0 - 1 for (m0, _u) in support}
         tmap = _truth_map(truth_parquet, lr_full, months)
         # (2) stream arm-by-arm: load one arm's cubes, score all h, FREE before next (OOM guard)
         arms = list(registry)

--- a/reports/2026-07-29_v2_scoreboard_dossier/tools/score_v2_horizons.py
+++ b/reports/2026-07-29_v2_scoreboard_dossier/tools/score_v2_horizons.py
@@ -141,7 +141,11 @@ def score_horizons_v2(
         )
         if not support:
             raise ValueError(f"[{tgt}] EMPTY fixed support across models/horizons — FAIL")
+        # `| {m0-1}` is the persistence baseline's history month. Without it the FIRST origin
+        # (which has no predecessor to supply it as a forecast month) silently scored as all
+        # zeros — GH #282.
         months = {m0 + h - 1 for (m0, _u) in support for h in horizons}
+        months |= {m0 - 1 for (m0, _u) in support}
         tmap = _truth_map(truth_parquet, lr_full, months)
         for entry in list(registry):
             label, pdir, lr_tmpl, by_tmpl = entry[0], entry[1], entry[2], entry[3]
@@ -153,7 +157,7 @@ def score_horizons_v2(
                 rows.append(_metric_row(label, g, support, tmap, tgt, h, thr))
             del g  # free this arm's cubes before the next (OOM guard)
         if add_persistence:
-            gp = _persistence_gathered(tmap, support, horizons)
+            gp = _persistence_gathered(tmap, support, horizons, months_loaded=months)
             for h in horizons:
                 rows.append(_metric_row("persistence", gp, support, tmap, tgt, h, None))
     return rows

--- a/reports/2026-08-22_state_freeze_l300_dossier/tools/run_freeze_l300.sh
+++ b/reports/2026-08-22_state_freeze_l300_dossier/tools/run_freeze_l300.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# run_freeze_l300.sh — does freezing recurrent state still help at 300 lessons?
+#
+# M8 says freezing recurrent state recovers gate AP h18 0.0070 -> 0.0912. It was measured on
+# `truncated_smoke`: 40 lessons, ONE seed. M28 now classifies that vehicle as a smoke test with no
+# skill at any horizon, and the pre-registered violet_visitor confirmation was never run — which is
+# why M8 is the primary suspect in #280.
+#
+# The number that makes this worth an overnight: M8's RECOVERED value (0.0912) is 3.6x BELOW what a
+# 300-lesson model scores free-running with no intervention at all (0.3298, M34). So we do not know
+# whether state-freezing helps a model that actually works, does nothing, or hurts.
+#
+# Emit-only on existing weights. No training, no new code — run_freeze_arms.py already takes any
+# model+artifact.
+set -uo pipefail
+HYD=/home/simon/Documents/scripts/views_platform/views-hydranet
+D="$HYD/reports/2026-08-22_state_freeze_l300_dossier"; RES="$D/results"
+FT="$HYD/reports/2026-08-15_state_freeze_dossier/tools"
+MODELS=/home/simon/Documents/scripts/views_platform/views-models/models
+CENV="conda run --no-capture-output -n views-hydranet-env"
+
+# two seeds, so a difference is not one draw. Both are eps=0 L=300 arms whose free-running AP is
+# already published (M34): seed 43 h18 0.3318, seed 42 h18 0.3298.
+SEEDS=(
+  "fullzero_fortythree|calibration_model_20260821_045948.pt"
+  "fullzero_fortytwo|calibration_model_20260818_221401.pt"
+)
+ARMS=none,hidden,cell,all
+
+mkdir -p "$RES"; rm -f "$RES/FREEZE_DONE"
+exec 6>"$RES/.freeze.lock"; flock -n 6 || { echo "another run holds the lock"; exit 11; }
+log(){ _m="[$(date '+%F %T')] freeze300: $*"; echo "$_m" >> "$RES/run.log"; [ -t 2 ] && echo "$_m" >&2; return 0; }
+
+HEAD_SHA=$(cd "$HYD" && git rev-parse HEAD)
+log "=== state-freeze at L=300 · HEAD ${HEAD_SHA:0:12} · ${#SEEDS[@]} seeds x 4 arms ==="
+FAILED=""
+for spec in "${SEEDS[@]}"; do
+  M="${spec%%|*}"; ART="${spec##*|}"
+  free=$(df -BG "$MODELS" | tail -1 | awk '{print $4}' | tr -d 'G')
+  case "$free" in ''|*[!0-9]*) log "ABORT — cannot read df"; exit 13;; esac
+  [ "$free" -ge 25 ] || { log "ABORT — ${free}G free"; exit 13; }
+  [ -f "$MODELS/$M/artifacts/$ART" ] || { log "SKIP $M — artifact missing"; FAILED="$FAILED $M"; continue; }
+  n=$(ls -d "$MODELS/$M"/data/generated/predictions_* 2>/dev/null | wc -l)
+  [ "$n" -eq 0 ] || { log "ABORT — $n leftover cube(s) in $M"; exit 3; }
+
+  log "--- $M ($ART) · arms $ARMS ---"
+  t0=$(date +%s)
+  timeout -k 120 21600 $CENV python "$FT/run_freeze_arms.py" \
+      --model "$M" --artifact "$ART" --arms "$ARMS" --out "$RES" >> "$RES/${M}_freeze.log" 2>&1
+  rc=$?
+  [ $rc -eq 0 ] && log "$M OK in $(( ($(date +%s)-t0)/60 )) min" || { log "$M FAILED rc=$rc"; FAILED="$FAILED $M"; }
+  for d in "$MODELS/$M"/data/generated/predictions_*; do
+    [ -e "$d" ] && { log "  cleaning leftover $(basename "$d")"; rm -rf "$d"; }
+  done
+done
+echo "$HEAD_SHA" > "$RES/repo.head"
+[ -z "$FAILED" ] || { log "FAILED:$FAILED"; exit 1; }
+touch "$RES/FREEZE_DONE"
+log "=== DONE ==="

--- a/tests/test_score_v2_horizons.py
+++ b/tests/test_score_v2_horizons.py
@@ -131,3 +131,61 @@ def test_h1_matches_frozen_lodestar(fixture):
     assert h1["crps_none"] == pytest.approx(lode["crps_none"])
     assert h1["size_ratio"] == pytest.approx(lode["size_ratio"])
     assert h1["pos_mcr"] == pytest.approx(lode["pos_mcr"])
+
+
+# --- GH #282: the persistence baseline's history month was never loaded -------------------------
+
+
+def _rollout_skill_mod():
+    """Import the sibling that owns `_persistence_gathered` (dossier tool, force-tracked)."""
+    p = _HN / "reports/2026-07-25_t0_rollout_skill_dossier/tools/rollout_skill_score.py"
+    if not p.exists():
+        pytest.skip("rollout_skill_score.py absent — sparse checkout (C-247)")
+    spec = importlib.util.spec_from_file_location("rollout_skill_score", p)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["rollout_skill_score"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_persistence_refuses_when_the_history_month_was_never_loaded():
+    """GH #282, the guard.
+
+    `score_horizons_v2` built `tmap` from `{m0+h-1}` only. `_persistence_gathered` reads
+    `truth_map[(m0-1, u)]`, which is present ONLY because origins are usually consecutive — origin
+    k's history is origin k-1's h=1 forecast month. The FIRST origin has no predecessor, so its
+    history fell through `.get(..., 0.0)` and its whole persistence forecast became zeros, with no
+    error. Understated the baseline by 4-10% at 13 origins, and by everything at one.
+    """
+    rs = _rollout_skill_mod()
+    support = [(100, 1), (101, 1)]
+    tmap = {(100, 1): 5.0, (101, 1): 6.0}
+    with pytest.raises(ValueError, match="never loaded"):
+        rs._persistence_gathered(tmap, support, (1,), months_loaded={100, 101})
+
+
+def test_persistence_accepts_a_truth_map_that_includes_the_history_months():
+    rs = _rollout_skill_mod()
+    support = [(100, 1), (101, 1)]
+    tmap = {(99, 1): 5.0, (100, 1): 7.0, (101, 1): 6.0}
+    got = rs._persistence_gathered(tmap, support, (1,), months_loaded={99, 100, 101})
+    assert float(got[(100, 1, 1)][0][0]) == 5.0  # truth[m0-1], not truth[m0]
+    assert float(got[(101, 1, 1)][0][0]) == 7.0
+
+
+def test_both_scorers_load_the_pre_origin_month():
+    """The fix must live in BOTH scorers, or one of them silently keeps the defect.
+
+    Asserted on source text because the alternative is building two full cube fixtures for a
+    one-line set-union; the runtime guard above is what actually protects the number.
+    """
+    for tool in (
+        _V2_TOOL,
+        _HN / "reports/2026-07-25_t0_rollout_skill_dossier/tools/rollout_skill_score.py",
+    ):
+        if not tool.exists():
+            pytest.skip(f"{tool.name} absent — sparse checkout (C-247)")
+        src = tool.read_text()
+        assert "months |= {m0 - 1 for (m0, _u) in support}" in src, (
+            f"{tool.name} does not load the persistence history month — GH #282 regressed"
+        )


### PR DESCRIPTION
## The defect

`score_horizons_v2` and `score_horizons` both build the truth map from the **scored** months
`{m0+h-1}`, while `_persistence_gathered` reads `truth_map[(m0-1, u)]`.

That month is present only **by accident** — origins are usually consecutive, so origin *k*'s history
is origin *k−1*'s h=1 forecast month. **The first origin has no predecessor**, so its history fell
through `.get(..., 0.0)` and its entire persistence forecast became zeros. No error, no warning.

| h | persistence AP as scored | correct | understated by |
|--:|--:|--:|--:|
| 1 | 0.1461 | 0.1632 | −10.5% |
| 18 | 0.1077 | 0.1152 | −6.5% |
| 36 | 0.0834 | 0.0870 | −4.1% |

It **scales as `1/n_origins`** — a single-origin study scores persistence as all zeros and is told
nothing. The direction always **flatters the arms**, which is why it survived: every comparison
looked better than it was, including ledger **M1** and the **C-293** measurement.

## The fix

**Both scorers.** `rollout_skill_score.score_horizons` carried the identical `months` line, so the
shared `_persistence_gathered` made one defect look like one fix — it needed two.

The guard follows the standing rule for this class (**delete the ambiguity, don't add a default**):

* a missing **cell** inside a loaded month is a legitimate `0.0` — `_truth_map` builds a dense
  per-month dict, the convention `rollout_ruler_core` documents;
* a missing **month** is not a measurement at all.

`.get(..., 0.0)` could not tell them apart. `_persistence_gathered` now takes `months_loaded` and
**raises**. It is optional rather than required so archived analyses that reconstruct the call still
run — but they run *wrong*, which is why every live caller passes it.

## Both tests sabotage-verified

| remove | test that fails |
|---|---|
| the `months \|=` line | `test_both_scorers_load_the_pre_origin_month` |
| the runtime guard | `test_persistence_refuses_when_the_history_month_was_never_loaded` |

Verified by actually deleting each and re-running, not by inspection.

## Not fixed, recorded

`rollout_skill_score.py` is **force-tracked but lives under gitignored `reports/`**, so
`ruff check .` never scans it — it carries **16 pre-existing E501s** nobody has seen. Same shape as
the C-247 story about its sibling. Only the line this PR touched was brought under 99 chars; the rest
is out of scope and belongs in its own change.

## Also in this branch

`reports/2026-08-22_state_freeze_l300_dossier/tools/run_freeze_l300.sh` — the driver for the
state-freeze-at-L=300 run now executing (**#280**'s primary suspect: **M8** was measured on a
40-lesson vehicle, and its *recovered* AP of 0.0912 is **3.6× below** what an L=300 model scores
free-running with no intervention at all). **Results are not in this PR** and will land separately.

Gates: `ruff check .` clean, **1629 passing**.

Closes #282. Related: C-248, C-293, #280.