### PR TITLE
Pushforward (#289) + the training-loop gradient audit that gated it — and the BN bug it found

### DIFF
--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -3340,7 +3340,7 @@ given a plausible cause.
 | Source | training-loop gradient audit (2026-08-26) |
 | Trigger | Writing a new arm config without `freeze_multitask_balancer: True`, or deliberately re-enabling the C-111 active balancer to revisit the C-113 bisect |
 | Location | `views_hydranet/utils/mtloss.py:66`; `views_hydranet/train/training_engine.py:1015` (`if w_loss > 0`) and `:1027` (`if lesson_loss > 0`) |
-| Cross-refs | C-111 (added `log_vars` to the optimizer), C-113 (the bisect the freeze flag exists for), C-314 |
+| Cross-refs | C-111 (added `log_vars` to the optimizer), C-113 (the bisect the freeze flag exists for), **C-170 and C-124 — the SAME trigger (un-freezing the balancer), different mechanism**: C-170 is about the Kendall weighting *starving* the rare targets, this is about the guards below it *stopping training altogether*. Anyone acting on C-170's mitigation must read this too.**, C-314 |
 
 `MultiTaskLoss.forward` returns `coeffs * losses + torch.log(stds + eps)`. The second term is
 **negative whenever `log_var < 0`**. Per task, `term(L, v) = L/((r+1)e^v) + v/2` is minimised at
@@ -3378,17 +3378,33 @@ backward-pass counter. Mutation-verified: removing either guard, or the `log(std
 | Source | training-loop gradient audit (2026-08-26) |
 | Trigger | Raising `_EPS`, changing `reg_activation` or the head's bias init, or training long/hard enough that the reg head's raw output approaches -13.8 |
 | Location | `views_hydranet/distributions/nb_core.py:20-24`; false claim at `views_hydranet/architectures/HydraBNrecurrentUnet_06_LSTM4.py:104-106` |
-| Cross-refs | C-178 (the original dead-ReLU root cause), C-199 / C-203 (theta dies if it saturates), C-303 (tenth occurrence) |
+| Cross-refs | **C-202 — same clamp, examined for `theta` ONLY and resolved on a theta-specific argument; `mu` was never in scope**; C-178 (the original dead-ReLU root cause), C-199 / C-203 (theta dies if it saturates), C-314 (the clip is the belt-and-braces C-202's resolution leans on), C-303 (tenth occurrence) |
 
 `_clamp` applies `clamp_min(_EPS)` with `_EPS = 1e-6` to both activated NB parameters. `clamp_min`
 passes zero gradient below its floor, so with a `softplus` head the dead-zone edge sits at exactly
 `softplus(raw) == 1e-6`, i.e. `raw == log(expm1(1e-6)) ≈ -13.8155`.
 
-The transition is **abrupt, not gradual**, and therefore a trap rather than a soft floor. On an
-active cell (`y=2`): `dNLL/d(raw_mu) = -6.389` at `raw_mu = -13.81`, and **exactly `0.0`** at
-`-13.82`, in both directions and for any target size. A unit that steps past the edge cannot climb
-back out. This is mechanically the failure C-178 was opened for and fixed by ReLU→softplus; the
-clamp reinstates it 13.8 nats lower down.
+The transition is **abrupt, not gradual**, and therefore a trap rather than a soft floor: the
+gradient is finite immediately above the edge and **exactly `0.0`** immediately below, in both
+directions and for any target. A unit that steps past the edge cannot climb back out. This is
+mechanically the failure C-178 was opened for and fixed by ReLU→softplus; the clamp reinstates it
+13.8 nats lower down.
+
+**Relationship to C-202 — the real gap.** C-202 asked whether this same `_EPS` floor causes a
+head-channel gradient explosion, and answered *no*, correctly: `dtheta/d(raw) = sigmoid(raw) -> 0`
+cancels the `1/theta` term. But that argument, its test and its Location field are all about
+**`theta`**. The identical clamp applies to **`mu`**, where the cancellation does not occur —
+measured, with targets in log1p space as the loss expects, `|dNLL/d(raw_mu)|` just above the floor
+is approximately **the observed count** (5.0 at count 5, 5000.0 at count 5000), against C-202's
+`1.5` theta bound. C-202 is not wrong; it is **incomplete**, and its resolution note reads as
+though the clamp question is settled for the head as a whole.
+
+**How remote, measured rather than asserted.** Severity depends strongly on `theta`. The -6.389
+figure quoted in early notes on this entry is at `theta = 0.693`; at the **incumbent's** measured
+operating point (`raw_mu = -3.81`, `raw_theta = -9.99`) the mu-channel gradient is `-0.207` at
+count 100 and `-2.07` at count 1000 — and its **sign pushes `mu` away from the cliff**, since any
+positive count raises `raw_mu`. The gap to the edge is 10.0 nats, i.e. ~48,000 unclipped
+`lr=1e-3` steps *in the wrong direction*. Tier 3 is if anything generous.
 
 **Latent, not active — measured, not assumed.** Running the trained L=300 incumbent
 (`fullzero_fortytwo`) forward on a sparse field, the reg heads' minimum raw outputs are `mu` **-3.81**
@@ -3416,7 +3432,7 @@ removing the clamp, fails.
 | Source | training-loop gradient audit (2026-08-26) |
 | Trigger | Tuning the clip threshold from config, or diagnosing an explosion by reading `max_raw_grad_norm` |
 | Location | `views_hydranet/train/training_engine.py:1080-1081` (clip), `:1053-1060` (raw-norm audit); `config_initializer.py` (`clip_grad_norm: bool`) |
-| Cross-refs | C-312 (the same parameters, unbounded in the loss), C-184 |
+| Cross-refs | C-312 (the same parameters, unbounded in the loss), **C-202 — its resolution explicitly leans on this clip as the belt-and-braces for legitimate large-count gradients, so an untested clip weakened a closed entry**, C-215 (per-lesson grad-norm not persisted), C-184 |
 
 Three distinct gaps in one guard:
 

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -4,12 +4,12 @@
 |-------------------|--------------------------------------|
 | Project           | views-hydranet                       |
 | Owner             | Simon Polichinel von der Maase       |
-| Last Updated      | 2026-08-22                           |
-| ID accounting     | C-188 merged into C-182 on 2026-08-15; C-275/C-276 added the same day; C-284..C-287 added 2026-08-15 from PR #274's `/code-review max`; C-260 relocated → §Resolved 2026-08-15 (fix verified in source + test); C-288 added 2026-08-15 from PR #276's CI failure; C-292/C-293 added 2026-08-16 from PR #277's code review; C-294/C-295 the same day from the architecture read it prompted; **C-289/C-290/C-291 added 2026-08-16 from PR #278 (feedback-realism), filling a gap C-292 already cross-referenced — they had been assigned in conversation and never written; C-296/C-297 added the same day from PR #278's code review and from authoring its fixes; C-298 added 2026-08-17 from the Claims Ledger verification pass; C-299/C-300 added 2026-08-17 from `postmortem_floor_limited_vehicle.md`; C-301/C-302 added 2026-08-18 from the code read behind the lesson-curve pre-registration; **C-303/C-304 added 2026-08-22 from PR #283's `/code-review medium` + `/review-diff`; **C-308 added 2026-08-23 (a probe measured the wrong rollout phase; every downstream guard still passed); C-307 added 2026-08-23 from the user's observation that cheap screens keep being recorded as closures — a pattern predating this session; C-305/C-306 added 2026-08-22 from PR #292's reviews, and C-303 escalated from three to FIVE occurrences — the fourth inside the provenance document written to prevent it;** the same pass MERGED two findings into existing entries rather than adding new ones — GH #282 (persistence baseline silently zeroed for the first origin) is a second, already-shipping symptom of C-248's unloaded pre-origin months, and C-293's "AP is a ranking statistic so the comparison is valid" was CORRECTED: at S=1 with no gate, persistence is ranked on a two-level score while gated arms get a continuous probability.** `C-34`/`C-188` are intentional numbering gaps (merged entries). |
-| Total Concerns    | 308                                  |
-| Open Concerns     | 156                                  |
+| Last Updated      | 2026-08-26                           |
+| ID accounting     | C-188 merged into C-182 on 2026-08-15; C-275/C-276 added the same day; C-284..C-287 added 2026-08-15 from PR #274's `/code-review max`; C-260 relocated → §Resolved 2026-08-15 (fix verified in source + test); C-288 added 2026-08-15 from PR #276's CI failure; C-292/C-293 added 2026-08-16 from PR #277's code review; C-294/C-295 the same day from the architecture read it prompted; **C-289/C-290/C-291 added 2026-08-16 from PR #278 (feedback-realism), filling a gap C-292 already cross-referenced — they had been assigned in conversation and never written; C-296/C-297 added the same day from PR #278's code review and from authoring its fixes; C-298 added 2026-08-17 from the Claims Ledger verification pass; C-299/C-300 added 2026-08-17 from `postmortem_floor_limited_vehicle.md`; C-301/C-302 added 2026-08-18 from the code read behind the lesson-curve pre-registration; **C-303/C-304 added 2026-08-22 from PR #283's `/code-review medium` + `/review-diff`; **C-308 added 2026-08-23 (a probe measured the wrong rollout phase; every downstream guard still passed); C-307 added 2026-08-23 from the user's observation that cheap screens keep being recorded as closures — a pattern predating this session; C-305/C-306 added 2026-08-22 from PR #292's reviews, and C-303 escalated from three to FIVE occurrences — the fourth inside the provenance document written to prevent it;** the same pass MERGED two findings into existing entries rather than adding new ones — GH #282 (persistence baseline silently zeroed for the first origin) is a second, already-shipping symptom of C-248's unloaded pre-origin months, and C-293's "AP is a ranking statistic so the comparison is valid" was CORRECTED: at S=1 with no gate, persistence is ranked on a two-level score while gated arms get a continuous probability.** **C-312..C-315 added 2026-08-26 from the training-loop gradient audit (forward/backward/gradient flow, ahead of the pushforward arm); the same pass recorded C-303's TENTH occurrence — the first inside production source rather than a report.** `C-34`/`C-188` are intentional numbering gaps (merged entries). |
+| Total Concerns    | 312                                  |
+| Open Concerns     | 160                                  |
 | — of which demoted (tech-debt) | 13 (tagged `[DEMOTED]` in §Open Concerns; indexed in §Tech-Debt Backlog) |
-| — net active risks | 132                                 |
+| — net active risks | 136                                 |
 | Resolved Concerns | 152                                  |
 | Last curation pass | **2026-08-15 (review-rr strategic).** 24 entries relocated §Open → §Resolved: the 12 PR-#216 bannered entries (C-138/234/235/236/237/238/239/240/241/242/243/247) whose relocation this header had flagged as pending, plus 12 whose fixes were verified in source but never recorded (C-132/146/179/180/193/194/195/196/197/201/251 + C-184, the last with residual C-273). C-188 merged into C-182; C-134 re-tiered 2→3; 7 Tier-4 entries demoted; 2 causal clusters added (14 positional coupling, 15 register↔code sync). Open 145 → 120, then → 122 with 2 blind-spot entries registered the same day (C-275 data vintage, C-276 forecast monitoring). |
 
@@ -2784,7 +2784,7 @@ clear persistence at every horizon (ledger M34, n=4) — which is what this entr
 
 ---
 
-### C-303: prose asserts a guard the code does not implement — NINE occurrences, one of which rendered a WRONG VERDICT
+### C-303: prose asserts a guard the code does not implement — TEN occurrences, one of which rendered a WRONG VERDICT
 
 | Field | Value |
 |-------|-------|
@@ -3071,6 +3071,15 @@ is not repeated.
 
 ---
 
+**TENTH INSTANCE, 2026-08-26 (training-loop gradient audit) — the first one inside production
+source rather than a report.** `HydraBNrecurrentUnet_06_LSTM4.py:104-106` explains the C-178 fix and
+concludes: *"softplus is always positive with non-zero gradient, **so it cannot die**."* The first
+clause is true; the conclusion is false, because `nb_core._clamp` applies `clamp_min(1e-6)` to the
+activated `mu` and `theta` immediately downstream, and `clamp_min` passes **exactly zero** gradient
+below its floor. Measured: `dNLL/d(raw_mu)` is `-6.389` at `raw_mu = -13.81` and `0.0` at `-13.82`.
+The comment describes the activation in isolation and is read as a property of the path. Registered
+in full as **C-313**, which also carries the pinning tests.
+
 ### C-304: dossier result directories accumulate state across runs — keyed by index, never cleared, silently mixable
 
 | Field | Value |
@@ -3321,6 +3330,159 @@ than its name implies, and nothing in the harness compares the two.
 with both directions tested. **Not fixed:** what emptied that directory is unknown — the config
 timestamps say 02:08 and no rebuild appears in the queue log. Recorded as unexplained rather than
 given a plausible cause.
+
+### C-312: the multi-task balancer can drive the loss negative, and two guards then stop training in silence
+
+| Field | Value |
+|-------|-------|
+| ID | C-312 |
+| Tier | 2 |
+| Source | training-loop gradient audit (2026-08-26) |
+| Trigger | Writing a new arm config without `freeze_multitask_balancer: True`, or deliberately re-enabling the C-111 active balancer to revisit the C-113 bisect |
+| Location | `views_hydranet/utils/mtloss.py:66`; `views_hydranet/train/training_engine.py:1015` (`if w_loss > 0`) and `:1027` (`if lesson_loss > 0`) |
+| Cross-refs | C-111 (added `log_vars` to the optimizer), C-113 (the bisect the freeze flag exists for), C-314 |
+
+`MultiTaskLoss.forward` returns `coeffs * losses + torch.log(stds + eps)`. The second term is
+**negative whenever `log_var < 0`**. Per task, `term(L, v) = L/((r+1)e^v) + v/2` is minimised at
+`v* = log(L/(r+1))`, giving `term = 1/2 + log(L/(r+1))/2` — **negative once `L < (r+1)/e`**. That is
+not an exotic regime; it is what a well-fitted task looks like, and `v*` is exactly where gradient
+descent on `log_vars` is heading.
+
+ADR-014's guards read as "skip empty windows", but they key on the **sign of a quantity the balancer
+can make negative**. When it does, `backward()` is skipped at `:1015` and `optimizer.step()` at
+`:1027` — with no warning, no log record above DEBUG and no counter. The progress bar advances, the
+loss curves are written, wandb receives rows, and the run is externally indistinguishable from a
+healthy one.
+
+**Measured** on the `loop_config` vehicle with `log_vars` placed at their own fixed point: **2
+optimizer updates across 6 lessons**, versus 6 of 6 for the frozen control, same seed and data.
+
+**Not currently exposed.** Every live arm config — the incumbents and all six architecture bake-off
+arms — sets `freeze_multitask_balancer: True`, which pins `log_vars` at 0 so `log(stds) = 0` and
+every term is non-negative. No past result is in question. But the **config default is `False`**
+(`config_initializer.py:274`), so the exposure is one omitted line away, and 114 of the 156 model
+configs in views-models do not mention the flag at all.
+
+**Not fixed** (C-112: changing the loss would make pre/post metrics incomparable). Pinned by
+`tests/train/test_backward_gate.py`, 8 tests including a frozen-balancer control and a
+backward-pass counter. Mutation-verified: removing either guard, or the `log(stds)` term, fails.
+
+---
+
+### C-313: the NB clamp reinstates the C-178 dead-gradient trap that the architecture comment says is gone
+
+| Field | Value |
+|-------|-------|
+| ID | C-313 |
+| Tier | 3 |
+| Source | training-loop gradient audit (2026-08-26) |
+| Trigger | Raising `_EPS`, changing `reg_activation` or the head's bias init, or training long/hard enough that the reg head's raw output approaches -13.8 |
+| Location | `views_hydranet/distributions/nb_core.py:20-24`; false claim at `views_hydranet/architectures/HydraBNrecurrentUnet_06_LSTM4.py:104-106` |
+| Cross-refs | C-178 (the original dead-ReLU root cause), C-199 / C-203 (theta dies if it saturates), C-303 (tenth occurrence) |
+
+`_clamp` applies `clamp_min(_EPS)` with `_EPS = 1e-6` to both activated NB parameters. `clamp_min`
+passes zero gradient below its floor, so with a `softplus` head the dead-zone edge sits at exactly
+`softplus(raw) == 1e-6`, i.e. `raw == log(expm1(1e-6)) ≈ -13.8155`.
+
+The transition is **abrupt, not gradual**, and therefore a trap rather than a soft floor. On an
+active cell (`y=2`): `dNLL/d(raw_mu) = -6.389` at `raw_mu = -13.81`, and **exactly `0.0`** at
+`-13.82`, in both directions and for any target size. A unit that steps past the edge cannot climb
+back out. This is mechanically the failure C-178 was opened for and fixed by ReLU→softplus; the
+clamp reinstates it 13.8 nats lower down.
+
+**Latent, not active — measured, not assumed.** Running the trained L=300 incumbent
+(`fullzero_fortytwo`) forward on a sparse field, the reg heads' minimum raw outputs are `mu` **-3.81**
+and `theta` **-9.99**, against an edge of -13.82. No past result is affected.
+
+**Second finding, same probe:** `tests/distributions/test_theta_gradient_bound.py` asserts
+`|d/d raw_theta| <= 1.5` at `raw_theta = -16.0`. That point is **inside the dead zone**, so the bound
+is satisfied by a gradient of exactly `0.0` — by the channel being dead, not by softplus cancelling
+an explosion as the docstring claims. Its `-10` and `-13` rows are above the edge and do demonstrate
+the cancellation, so the test is sound apart from that one vacuous row; the row is documented rather
+than deleted, because deleting it would erase the evidence that the trap exists.
+
+**Not fixed** (C-112). Pinned by `tests/distributions/test_gradient_dead_zones.py`, 6 tests deriving
+the edge from `_EPS` rather than hardcoding it. Mutation-verified: raising `_EPS` to 1e-3, or
+removing the clamp, fails.
+
+---
+
+### C-314: the gradient clip is unconfigurable, was untested, and does not cover the balancer
+
+| Field | Value |
+|-------|-------|
+| ID | C-314 |
+| Tier | 3 |
+| Source | training-loop gradient audit (2026-08-26) |
+| Trigger | Tuning the clip threshold from config, or diagnosing an explosion by reading `max_raw_grad_norm` |
+| Location | `views_hydranet/train/training_engine.py:1080-1081` (clip), `:1053-1060` (raw-norm audit); `config_initializer.py` (`clip_grad_norm: bool`) |
+| Cross-refs | C-312 (the same parameters, unbounded in the loss), C-184 |
+
+Three distinct gaps in one guard:
+
+1. **`max_norm=1.0` is a literal.** The `clip_grad_norm` config field is a **bool**, so the only
+   thing a config can say is on/off. Changing the threshold requires editing the engine.
+2. **It had zero behavioural coverage.** Deleting the call passed all 1630 tests. Measured on the
+   audit vehicle: raw norm **5.678 / 5.614**, clipped **exactly 1.0000** — a large, binding
+   intervention that nothing verified was happening.
+3. **It covers `model.parameters()` only.** `MultiTaskLoss.log_vars` is a separate optimizer param
+   group (C-111) and is therefore invisible to both the clip *and* the `max_raw_grad_norm` explosion
+   audit above it. Since `coeffs = 1 / ((is_regression + 1) * stds**2 + eps)` has no upper bound, an
+   unclipped `log_vars` is an unbounded amplifier on every task loss, unwatched by the guard whose
+   job is to notice exactly that.
+
+(1) and (3) are **not fixed** (C-112). (2) is closed:
+`tests/train/test_gradient_health.py` observes the gradient norm the optimizer is actually handed,
+which is what makes it survive the mutations — a test that patched `clip_grad_norm_` would have
+verified we call a function, not that the gradient is bounded. Mutation-verified: deleting the call
+and raising `max_norm` to 100.0 both fail.
+
+---
+
+### C-315: the training graph is untruncated over the full time axis, and only explosion is monitored
+
+| Field | Value |
+|-------|-------|
+| ID | C-315 |
+| Tier | 3 |
+| Source | training-loop gradient audit (2026-08-26) |
+| Trigger | Adding any per-step auxiliary term to `_process_sequence` (pushforward #289, GTF #294, BPTT-SA #288), or raising `window_dim` / the training time axis |
+| Location | `views_hydranet/train/training_engine.py:350` (state rebound un-detached), `:1016` (the single `backward`), `:1053-1060` (explosion-only audit); `views_hydranet/utils/volume_sampler.py:88` |
+| Cross-refs | C-07 (per-window memory release), C-246 (the T-loop implemented twice) |
+
+There is **no BPTT truncation of any kind**. `h` is rebound to `output.h_next` with no `detach`,
+`total_loss` accumulates every step, and there is exactly one `.backward()` in the package, called
+once per *window* over all `seq_len - 1` steps. `VolumeSampler._generate_window` slices space only,
+so `seq_len` is the full training time axis — ~383 steps in a production run. Every window therefore
+holds a ~383-step autograd graph through 4 ConvLSTMs, a U-Net and six decoder branches until
+backward. That is consistent with the 4.1–4.7 GiB the bake-off smoke measured.
+
+This is a deliberate design and, on the evidence below, a *justified* one — but it was undocumented,
+untested, and it bounds what can be added to the step loop. **Any per-step auxiliary term
+approximately doubles the largest object in the run**; `#289`'s pushforward does exactly that, with
+`pf_h = h` un-detached by default.
+
+**The reach is real, and this corrects a prior.** Measuring `d||h_final||²/dx_i` at T=120 — which
+isolates the recurrent path, since a frame can only reach `h_final` through memory:
+
+| steps back | random init | trained L=300 |
+|---|---|---|
+| 0 | 1.14e+01 | 5.56e+01 |
+| 20 | 1.40e-03 | 3.94e+00 |
+| 60 | 2.98e-09 | 2.65e-01 |
+| 118 | 2.81e-17 | 1.56e-02 |
+
+The untrained recurrence is sharply contractive and geometric — `MillerHardt2019`'s stable regime,
+where a truncated feed-forward model approximates it and the memory is decorative. **Training escapes
+that regime**: the trained decay is sub-exponential and retains ~1e14× more gradient at 118 steps
+back. So truncating BPTT would discard real signal, and **M46's `WideMemory` null is not a
+vanishing-gradient story** — whatever caps that arm, it is not gradient failing to reach the
+recurrence.
+
+**Residual gap:** `max_raw_grad_norm` watches only for explosion. Nothing in the run measures
+vanishing, so a future change that collapses the recurrence back toward the random-init regime would
+be silent. Pinned by `tests/train/test_bptt_reach.py`; mutation-verified (inserting `.detach()` in
+the state carry fails).
 
 ## Disagreements
 

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -3458,9 +3458,21 @@ holds a ~383-step autograd graph through 4 ConvLSTMs, a U-Net and six decoder br
 backward. That is consistent with the 4.1–4.7 GiB the bake-off smoke measured.
 
 This is a deliberate design and, on the evidence below, a *justified* one — but it was undocumented,
-untested, and it bounds what can be added to the step loop. **Any per-step auxiliary term
-approximately doubles the largest object in the run**; `#289`'s pushforward does exactly that, with
-`pf_h = h` un-detached by default.
+untested, and it bounds what can be added to the step loop.
+
+**Measured cost of adding one** (`#289` pushforward, one production-shaped window — `window_dim=32`,
+`T=336`, RTX 4070):
+
+| | peak allocated | fwd | fwd+bwd |
+|---|---|---|---|
+| `pushforward_weight=0` | 2524 MiB | 2.46 s | 4.58 s |
+| `=1`, state attached | 3993 MiB | 4.24 s | 7.58 s |
+| `=1`, state detached | 3993 MiB | 4.04 s | 7.34 s |
+
+So **+58% memory and ×1.65 wall-clock**, not the doubling a first reading of the graph suggests —
+the extra step is one level deep from a detached field, not a second full sequence. Extrapolating
+from the incumbent's measured 1.82 h/arm gives **~3.0 h/arm**. `pushforward_detach_state` costs
+nothing either way, so that fork is free to test.
 
 **The reach is real, and this corrects a prior.** Measuring `d||h_final||²/dx_i` at T=120 — which
 isolates the recurrent path, since a frame can only reach `h_final` through memory:

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -5,11 +5,11 @@
 | Project           | views-hydranet                       |
 | Owner             | Simon Polichinel von der Maase       |
 | Last Updated      | 2026-08-26                           |
-| ID accounting     | C-188 merged into C-182 on 2026-08-15; C-275/C-276 added the same day; C-284..C-287 added 2026-08-15 from PR #274's `/code-review max`; C-260 relocated → §Resolved 2026-08-15 (fix verified in source + test); C-288 added 2026-08-15 from PR #276's CI failure; C-292/C-293 added 2026-08-16 from PR #277's code review; C-294/C-295 the same day from the architecture read it prompted; **C-289/C-290/C-291 added 2026-08-16 from PR #278 (feedback-realism), filling a gap C-292 already cross-referenced — they had been assigned in conversation and never written; C-296/C-297 added the same day from PR #278's code review and from authoring its fixes; C-298 added 2026-08-17 from the Claims Ledger verification pass; C-299/C-300 added 2026-08-17 from `postmortem_floor_limited_vehicle.md`; C-301/C-302 added 2026-08-18 from the code read behind the lesson-curve pre-registration; **C-303/C-304 added 2026-08-22 from PR #283's `/code-review medium` + `/review-diff`; **C-308 added 2026-08-23 (a probe measured the wrong rollout phase; every downstream guard still passed); C-307 added 2026-08-23 from the user's observation that cheap screens keep being recorded as closures — a pattern predating this session; C-305/C-306 added 2026-08-22 from PR #292's reviews, and C-303 escalated from three to FIVE occurrences — the fourth inside the provenance document written to prevent it;** the same pass MERGED two findings into existing entries rather than adding new ones — GH #282 (persistence baseline silently zeroed for the first origin) is a second, already-shipping symptom of C-248's unloaded pre-origin months, and C-293's "AP is a ranking statistic so the comparison is valid" was CORRECTED: at S=1 with no gate, persistence is ranked on a two-level score while gated arms get a continuous probability.** **C-312..C-315 added 2026-08-26 from the training-loop gradient audit (forward/backward/gradient flow, ahead of the pushforward arm); the same pass recorded C-303's TENTH occurrence — the first inside production source rather than a report.** `C-34`/`C-188` are intentional numbering gaps (merged entries). |
-| Total Concerns    | 312                                  |
-| Open Concerns     | 160                                  |
+| ID accounting     | C-188 merged into C-182 on 2026-08-15; C-275/C-276 added the same day; C-284..C-287 added 2026-08-15 from PR #274's `/code-review max`; C-260 relocated → §Resolved 2026-08-15 (fix verified in source + test); C-288 added 2026-08-15 from PR #276's CI failure; C-292/C-293 added 2026-08-16 from PR #277's code review; C-294/C-295 the same day from the architecture read it prompted; **C-289/C-290/C-291 added 2026-08-16 from PR #278 (feedback-realism), filling a gap C-292 already cross-referenced — they had been assigned in conversation and never written; C-296/C-297 added the same day from PR #278's code review and from authoring its fixes; C-298 added 2026-08-17 from the Claims Ledger verification pass; C-299/C-300 added 2026-08-17 from `postmortem_floor_limited_vehicle.md`; C-301/C-302 added 2026-08-18 from the code read behind the lesson-curve pre-registration; **C-303/C-304 added 2026-08-22 from PR #283's `/code-review medium` + `/review-diff`; **C-308 added 2026-08-23 (a probe measured the wrong rollout phase; every downstream guard still passed); C-307 added 2026-08-23 from the user's observation that cheap screens keep being recorded as closures — a pattern predating this session; C-305/C-306 added 2026-08-22 from PR #292's reviews, and C-303 escalated from three to FIVE occurrences — the fourth inside the provenance document written to prevent it;** the same pass MERGED two findings into existing entries rather than adding new ones — GH #282 (persistence baseline silently zeroed for the first origin) is a second, already-shipping symptom of C-248's unloaded pre-origin months, and C-293's "AP is a ranking statistic so the comparison is valid" was CORRECTED: at S=1 with no gate, persistence is ranked on a two-level score while gated arms get a continuous probability.** **C-312..C-315 added 2026-08-26 from the training-loop gradient audit (forward/backward/gradient flow, ahead of the pushforward arm); the same pass recorded C-303's TENTH occurrence — the first inside production source rather than a report. C-316 added the same day (test-suite pollution found because the new tests failed only in full-suite runs). **C-312 FIXED and C-314 partly fixed on the same branch; C-313 and C-315 remain open by decision (C-112: changing the clamp or clipping the balancer would move training dynamics). C-312 and C-303 carry FIXED banners but stay in §Open pending the next curation relocation, as C-184 and the PR-#216 entries did.** `C-34`/`C-188` are intentional numbering gaps (merged entries). |
+| Total Concerns    | 313                                  |
+| Open Concerns     | 161                                  |
 | — of which demoted (tech-debt) | 13 (tagged `[DEMOTED]` in §Open Concerns; indexed in §Tech-Debt Backlog) |
-| — net active risks | 136                                 |
+| — net active risks | 137                                 |
 | Resolved Concerns | 152                                  |
 | Last curation pass | **2026-08-15 (review-rr strategic).** 24 entries relocated §Open → §Resolved: the 12 PR-#216 bannered entries (C-138/234/235/236/237/238/239/240/241/242/243/247) whose relocation this header had flagged as pending, plus 12 whose fixes were verified in source but never recorded (C-132/146/179/180/193/194/195/196/197/201/251 + C-184, the last with residual C-273). C-188 merged into C-182; C-134 re-tiered 2→3; 7 Tier-4 entries demoted; 2 causal clusters added (14 positional coupling, 15 register↔code sync). Open 145 → 120, then → 122 with 2 blind-spot entries registered the same day (C-275 data vintage, C-276 forecast monitoring). |
 
@@ -3331,7 +3331,7 @@ with both directions tested. **Not fixed:** what emptied that directory is unkno
 timestamps say 02:08 and no rebuild appears in the queue log. Recorded as unexplained rather than
 given a plausible cause.
 
-### C-312: the multi-task balancer can drive the loss negative, and two guards then stop training in silence
+### C-312: the multi-task balancer can drive the loss negative, and two guards then stop training in silence — FIXED
 
 | Field | Value |
 |-------|-------|
@@ -3363,9 +3363,23 @@ every term is non-negative. No past result is in question. But the **config defa
 (`config_initializer.py:274`), so the exposure is one omitted line away, and 114 of the 156 model
 configs in views-models do not mention the flag at all.
 
-**Not fixed** (C-112: changing the loss would make pre/post metrics incomparable). Pinned by
-`tests/train/test_backward_gate.py`, 8 tests including a frozen-balancer control and a
-backward-pass counter. Mutation-verified: removing either guard, or the `log(stds)` term, fails.
+> **FIXED 2026-08-26.** The guards now ask ADR-014's actual question. A window backpropagates
+> unless its loss is **exactly zero** (the empty-window case ADR-014 means); a **non-finite** loss
+> now **raises** instead of being skipped like an empty window (a NaN used to fail `> 0` silently —
+> C-212 was exactly such a bug); and the optimization gate keys on `windows_trained > 0`, i.e.
+> whether gradient was actually produced. Measured after the fix: **6 of 6** lessons update, where
+> the old guards gave 2.
+>
+> **The C-112 comparability question is answered by measurement, not assertion.** Under
+> `freeze_multitask_balancer: True` the balancer contributes `log(stds) = 0` and every task term is
+> non-negative, so the old `> 0` and new `!= 0` select the same windows.
+> `test_the_new_guard_is_byte_identical_when_frozen` proves it by observing every window's total
+> during a real frozen-balancer run rather than re-deriving the algebra, so it stays true if the
+> loss composition changes. **No existing result moves.**
+>
+> Pinned by `tests/train/test_backward_gate.py` (10 tests). Mutation-verified: restoring the sign
+> guard, removing the empty-window skip, removing the optimization gate, removing the non-finite
+> check, and removing the `log(stds)` term are all caught.
 
 ---
 
@@ -3447,11 +3461,18 @@ Three distinct gaps in one guard:
    unclipped `log_vars` is an unbounded amplifier on every task loss, unwatched by the guard whose
    job is to notice exactly that.
 
-(1) and (3) are **not fixed** (C-112). (2) is closed:
-`tests/train/test_gradient_health.py` observes the gradient norm the optimizer is actually handed,
-which is what makes it survive the mutations — a test that patched `clip_grad_norm_` would have
-verified we call a function, not that the gradient is bounded. Mutation-verified: deleting the call
-and raising `max_norm` to 100.0 both fail.
+> **(1) and (2) FIXED 2026-08-26; (3) REMAINS OPEN.**
+>
+> (1) `clip_grad_max_norm: float = Field(default=1.0, gt=0.0)` replaces the literal. The default
+> keeps every pre-existing config byte-identical (`test_the_clip_default_is_unchanged_at_one`).
+> (2) `tests/train/test_gradient_health.py` observes the gradient norm the optimizer is actually
+> handed — a test that patched `clip_grad_norm_` would have verified we call a function, not that
+> the gradient is bounded. Mutation-verified: deleting the call, raising `max_norm` to 100.0, and
+> ignoring the new config field are all caught.
+>
+> **(3) is deliberately NOT fixed:** clipping `log_vars` changes training dynamics whenever the
+> balancer is active, which is a C-112 decision, not an audit side effect. The engine now carries
+> a comment saying so at the clip site. **This entry stays open on (3) alone.**
 
 ---
 
@@ -3511,6 +3532,37 @@ recurrence.
 vanishing, so a future change that collapses the recurrence back toward the random-init regime would
 be silent. Pinned by `tests/train/test_bptt_reach.py`; mutation-verified (inserting `.detach()` in
 the state carry fails).
+
+### C-316: a test deleted a live module from `sys.modules`, silently disarming every later monkeypatch of it
+
+| Field | Value |
+|-------|-------|
+| ID | C-316 |
+| Tier | 3 |
+| Source | training-loop gradient audit (2026-08-26), found while three new tests failed only in full-suite runs |
+| Trigger | Writing a test that reloads or removes a module from `sys.modules` in order to re-read it, when other modules already hold bound references into it |
+| Location | `tests/test_reproducibility_gate.py::test_training_engine_uses_lock_entropy`; guard added as `::test_the_live_training_engine_module_is_the_one_training_loop_uses` |
+| Cross-refs | C-303 / C-309 / C-311 (guards that check less than a reader assumes) |
+
+`test_training_engine_uses_lock_entropy` did `del sys.modules["views_hydranet.train.training_engine"]`
+and re-imported, purely so it could read the module's `__file__` and grep the source text. The
+delete was never needed for that, and it was never undone: for the rest of the session
+`views_hydranet.train.training_engine` was a **new** module object, while
+`train_model.training_loop` — already bound — kept executing against the **old** module's globals.
+
+**The consequence is exactly the failure mode this register keeps recording:** any later test that
+monkeypatched a `training_engine` attribute was patching an object nothing called. The patch
+appeared to succeed, the test ran, and it asserted against unpatched behaviour. Three tests in
+`tests/train/test_backward_gate.py` passed in isolation and failed **only** in a full-suite run,
+which is how it surfaced; a test written to be *less* strict would simply have passed, wrongly, in
+both.
+
+**Fixed** by reading the source through `Path(mod.__file__).read_text()` without touching
+`sys.modules`. **Guarded** by an assertion that `training_loop.__globals__` *is* the `__dict__` of
+the module currently in `sys.modules` — added because re-introducing the delete, once the three
+tests had been hardened to patch `training_loop.__globals__` directly, **survived the entire
+suite**. Hardening the victims removed the only signal that the defect existed; the guard restores
+it, and the mutation is now caught.
 
 ## Disagreements
 

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -3502,14 +3502,15 @@ untested, and it bounds what can be added to the step loop.
 
 | | peak allocated | fwd | fwd+bwd |
 |---|---|---|---|
-| `pushforward_weight=0` | 2524 MiB | 2.46 s | 4.58 s |
-| `=1`, state attached | 3993 MiB | 4.24 s | 7.58 s |
-| `=1`, state detached | 3993 MiB | 4.04 s | 7.34 s |
+| `pushforward_weight=0` | 2524 MiB | 3.22 s | 5.83 s |
+| `=1`, state attached | 3990 MiB | 6.01 s | 10.24 s |
+| `=1`, state detached | 3990 MiB | 5.97 s | 10.02 s |
 
-So **+58% memory and ×1.65 wall-clock**, not the doubling a first reading of the graph suggests —
+So **+58% memory and ×1.76 wall-clock**, not the doubling a first reading of the graph suggests —
 the extra step is one level deep from a detached field, not a second full sequence. Extrapolating
-from the incumbent's measured 1.82 h/arm gives **~3.0 h/arm**. `pushforward_detach_state` costs
-nothing either way, so that fork is free to test.
+from the incumbent's measured 1.82 h/arm gives **~3.2 h/arm**. `pushforward_detach_state` costs
+nothing either way, so that fork is free to test. (Re-measured after the BatchNorm-freeze fix,
+which adds a per-step module walk; the earlier figures were ×1.65 / ~3.0 h.)
 
 **The reach is real, and this corrects a prior.** Measuring `d||h_final||²/dx_i` at T=120 — which
 isolates the recurrent path, since a frame can only reach `h_final` through memory:

--- a/tests/distributions/test_gradient_dead_zones.py
+++ b/tests/distributions/test_gradient_dead_zones.py
@@ -15,7 +15,7 @@ This matters because it reinstates the failure mode C-178 was opened for and
     positive with non-zero gradient, so it cannot die."
 
 Softplus alone cannot die. Softplus *followed by* ``clamp_min(1e-6)`` can, and the transition is
-abrupt, not gradual — measured on an active cell (``y=2``):
+abrupt, not gradual — measured at ``raw_theta = 0`` on an active cell:
 
 ===================  ===========================
 ``raw_mu``           ``dNLL/d(raw_mu)``
@@ -23,6 +23,9 @@ abrupt, not gradual — measured on an active cell (``y=2``):
 -13.81               -6.389
 -13.82               **exactly 0.0**
 ===================  ===========================
+
+(at ``raw_theta = 0``, count 6.39. The magnitude is theta-dependent — see C-313 — but the drop to
+exactly zero below the edge is not.)
 
 Below the edge there is no gradient in either direction, so the unit cannot climb back out.
 
@@ -49,16 +52,22 @@ from views_hydranet.distributions.nb_core import _EPS  # noqa: E402
 EDGE = math.log(math.expm1(_EPS))
 
 
-def _grad_wrt_raw(raw_mu: float, raw_theta: float, y: float = 2.0):
-    """``dNLL/d(raw)`` through the REAL path: ``activate`` then ``nll``.
+def _grad_wrt_raw(raw_mu: float, raw_theta: float, count: float = 6.0):
+    """``dNLL/d(raw)`` through the REAL path, with the target in the space the loss expects.
 
-    Calling ``nll`` on raw values directly would silently measure a different function — the
-    family's contract is that ``nll`` receives *activated* params. Getting that wrong is how an
-    earlier pass of this audit produced a flat, meaningless gradient surface.
+    Two contracts are easy to get wrong here, and this audit got both wrong once before fixing them:
+
+    * ``nll`` receives **activated** params, not raw ones. Passing raw values measures a different
+      function entirely and yields a flat, meaningless gradient surface.
+    * ``target`` is in **log1p space** — ``nll`` recovers counts via ``to_raw_counts``. Passing a
+      raw count of 50 actually asks about a count of ``expm1(50) ≈ 5e21``, which manufactures a
+      spurious explosion.
+
+    ``count`` is therefore a real count and is log1p-transformed here.
     """
     family = get_family("nb")
     raw = torch.tensor([[raw_mu, raw_theta]], requires_grad=True)
-    nll = family.nll(family.activate(raw), torch.tensor([y]))
+    nll = family.nll(family.activate(raw), torch.log1p(torch.tensor([count])))
     (grad,) = torch.autograd.grad(nll, raw)
     return grad[0, 0].item(), grad[0, 1].item()
 
@@ -75,24 +84,27 @@ def test_the_dead_zone_edge_is_where_softplus_meets_the_clamp_floor():
 def test_mu_gradient_dies_abruptly_not_gradually_characterisation():
     """CHARACTERISATION (C-178 reinstated): the gradient does not fade, it stops.
 
-    The magnitude just above the edge is ~6.4 on an active cell. If the clamp merely damped a
-    gradient that was already negligible, this would be harmless bookkeeping; it does not.
+    Measured at ``raw_theta = 0`` (theta ~ 0.693) the magnitude just above the edge is ~6.4 — if
+    the clamp merely damped an already-negligible gradient this would be harmless bookkeeping, and
+    it does not. Note the magnitude is strongly theta-dependent: at the *incumbent's* operating
+    point (``raw_theta = -9.99``) it is ~0.2 at count 100 and points away from the cliff, which is
+    why C-313 is registered as remote rather than acute.
     """
-    alive, _ = _grad_wrt_raw(EDGE + 0.01, 0.0, y=2.0)
+    alive, _ = _grad_wrt_raw(EDGE + 0.01, 0.0, count=6.0)
     assert abs(alive) > 1.0, (
         f"gradient just above the clamp edge is only {alive:.3e}; the abrupt-cutoff framing of "
         "this finding no longer holds — re-measure before trusting the docstring above."
     )
     for depth in (0.01, 1.0, 5.0, 10.0):
-        dead, _ = _grad_wrt_raw(EDGE - depth, 0.0, y=2.0)
+        dead, _ = _grad_wrt_raw(EDGE - depth, 0.0, count=6.0)
         assert dead == 0.0, f"raw_mu={EDGE - depth:.4f}: expected exactly 0.0, got {dead}"
 
 
 def test_the_dead_zone_is_irrecoverable_in_both_directions():
     """No gradient means no way back. Confirms it is a trap, not a soft floor."""
-    for y in (0.0, 1.0, 10.0):
-        dead, _ = _grad_wrt_raw(EDGE - 2.0, 0.0, y=y)
-        assert dead == 0.0, f"y={y}: a target of any size should not revive the unit, got {dead}"
+    for count in (0.0, 1.0, 10.0):
+        dead, _ = _grad_wrt_raw(EDGE - 2.0, 0.0, count=count)
+        assert dead == 0.0, f"count={count}: no target size should revive the unit, got {dead}"
 
 
 def test_theta_dies_at_the_same_edge():

--- a/tests/distributions/test_gradient_dead_zones.py
+++ b/tests/distributions/test_gradient_dead_zones.py
@@ -1,0 +1,160 @@
+"""The NB parameter clamp is a gradient dead zone — where its edge is, and what it costs.
+
+``nb_core._clamp`` (``nb_core.py:23-24``) does::
+
+    return mu.clamp_min(_EPS), theta.clamp_min(_EPS)      # _EPS = 1e-6
+
+``clamp_min`` passes zero gradient below its threshold. The head activates with ``softplus``, so
+the boundary in raw (pre-activation) space is exactly ``softplus(raw) == 1e-6``, i.e.
+``raw == log(expm1(1e-6)) ≈ -13.8155``.
+
+This matters because it reinstates the failure mode C-178 was opened for and
+``HydraBNrecurrentUnet_06_LSTM4.py:104-106`` claims is gone:
+
+    "drifts 100% negative => ReLU==0 with zero gradient => unrecoverable). softplus is always
+    positive with non-zero gradient, so it cannot die."
+
+Softplus alone cannot die. Softplus *followed by* ``clamp_min(1e-6)`` can, and the transition is
+abrupt, not gradual — measured on an active cell (``y=2``):
+
+===================  ===========================
+``raw_mu``           ``dNLL/d(raw_mu)``
+===================  ===========================
+-13.81               -6.389
+-13.82               **exactly 0.0**
+===================  ===========================
+
+Below the edge there is no gradient in either direction, so the unit cannot climb back out.
+
+**Severity, measured rather than assumed.** Running the trained L=300 incumbent
+(``fullzero_fortytwo``) forward on a sparse field, the head's minimum raw values are ``mu``
+-3.81 and ``theta`` -9.99 — 3.8 and 3.8 nats clear of the edge. So this is a **latent** hazard on
+the current vehicle, not an active defect, and no past result is in question. It becomes live if
+``_EPS`` rises, if the head's activation or bias init changes, or if a longer/harder run pushes
+the head further down. These tests pin the edge so any of those is a visible break.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from views_hydranet.distributions import get_family  # noqa: E402
+from views_hydranet.distributions.nb_core import _EPS  # noqa: E402
+
+#: raw value at which ``softplus(raw)`` equals the clamp floor — derived, never hardcoded.
+EDGE = math.log(math.expm1(_EPS))
+
+
+def _grad_wrt_raw(raw_mu: float, raw_theta: float, y: float = 2.0):
+    """``dNLL/d(raw)`` through the REAL path: ``activate`` then ``nll``.
+
+    Calling ``nll`` on raw values directly would silently measure a different function — the
+    family's contract is that ``nll`` receives *activated* params. Getting that wrong is how an
+    earlier pass of this audit produced a flat, meaningless gradient surface.
+    """
+    family = get_family("nb")
+    raw = torch.tensor([[raw_mu, raw_theta]], requires_grad=True)
+    nll = family.nll(family.activate(raw), torch.tensor([y]))
+    (grad,) = torch.autograd.grad(nll, raw)
+    return grad[0, 0].item(), grad[0, 1].item()
+
+
+def test_the_dead_zone_edge_is_where_softplus_meets_the_clamp_floor():
+    """Pins the boundary itself. A change to ``_EPS`` or the activation moves it and fails here."""
+    assert torch.nn.functional.softplus(torch.tensor(EDGE)).item() == pytest.approx(_EPS, rel=1e-3)
+    just_above, _ = _grad_wrt_raw(EDGE + 0.01, 0.0)
+    just_below, _ = _grad_wrt_raw(EDGE - 0.01, 0.0)
+    assert just_above != 0.0, f"gradient already dead at raw_mu={EDGE + 0.01:.4f}"
+    assert just_below == 0.0, f"gradient still alive at raw_mu={EDGE - 0.01:.4f}: {just_below}"
+
+
+def test_mu_gradient_dies_abruptly_not_gradually_characterisation():
+    """CHARACTERISATION (C-178 reinstated): the gradient does not fade, it stops.
+
+    The magnitude just above the edge is ~6.4 on an active cell. If the clamp merely damped a
+    gradient that was already negligible, this would be harmless bookkeeping; it does not.
+    """
+    alive, _ = _grad_wrt_raw(EDGE + 0.01, 0.0, y=2.0)
+    assert abs(alive) > 1.0, (
+        f"gradient just above the clamp edge is only {alive:.3e}; the abrupt-cutoff framing of "
+        "this finding no longer holds — re-measure before trusting the docstring above."
+    )
+    for depth in (0.01, 1.0, 5.0, 10.0):
+        dead, _ = _grad_wrt_raw(EDGE - depth, 0.0, y=2.0)
+        assert dead == 0.0, f"raw_mu={EDGE - depth:.4f}: expected exactly 0.0, got {dead}"
+
+
+def test_the_dead_zone_is_irrecoverable_in_both_directions():
+    """No gradient means no way back. Confirms it is a trap, not a soft floor."""
+    for y in (0.0, 1.0, 10.0):
+        dead, _ = _grad_wrt_raw(EDGE - 2.0, 0.0, y=y)
+        assert dead == 0.0, f"y={y}: a target of any size should not revive the unit, got {dead}"
+
+
+def test_theta_dies_at_the_same_edge():
+    """The dispersion channel has the same clamp, and it is the one C-199/C-203 call fragile."""
+    _, alive = _grad_wrt_raw(0.0, EDGE + 0.01)
+    _, dead = _grad_wrt_raw(0.0, EDGE - 0.01)
+    assert alive != 0.0, "theta gradient already dead above the edge"
+    assert dead == 0.0, f"theta gradient still alive below the edge: {dead}"
+
+
+def test_the_existing_theta_bound_test_is_vacuous_at_its_deepest_point():
+    """``test_theta_gradient_bound.py`` asserts ``|d/d raw_theta| <= 1.5`` at ``raw_theta=-16.0``.
+
+    -16.0 is **inside** the dead zone (edge -13.8155), so at that point the bound is satisfied by
+    a gradient of exactly 0.0 — by the channel being dead, not by softplus cancelling an
+    explosion as its docstring claims. Its other sample points (-10, -13) are above the edge and
+    do demonstrate the cancellation, so the test is sound apart from this one vacuous row.
+
+    Asserted here rather than by editing that test, because deleting the row would erase the
+    evidence that the trap exists.
+    """
+    assert -16.0 < EDGE, "the -16.0 sample point is no longer inside the dead zone"
+    _, at_minus_16 = _grad_wrt_raw(0.0, -16.0)
+    assert at_minus_16 == 0.0, (
+        f"raw_theta=-16.0 now yields gradient {at_minus_16:.3e}; the vacuity this documents is "
+        "gone, so the note in test_theta_gradient_bound.py can go too."
+    )
+    _, at_minus_13 = _grad_wrt_raw(0.0, -13.0)
+    assert at_minus_13 != 0.0 and abs(at_minus_13) <= 1.5, (
+        "the -13.0 sample point should be alive AND bounded — that is the row that actually "
+        f"demonstrates the cancellation, got {at_minus_13:.4f}"
+    )
+
+
+def test_the_trained_incumbent_sits_clear_of_the_edge():
+    """Severity check: a randomly-initialised head must not already be in the trap.
+
+    The measured trained incumbent sits ~3.8 nats above the edge on both channels; this asserts
+    the weaker, checkpoint-free property that initialisation alone does not put the head there,
+    so the finding stays classified as latent.
+    """
+    from views_hydranet.architectures.registry import get_architecture
+
+    torch.manual_seed(0)
+    model = get_architecture("HydraBNUNet06_LSTM4")(
+        3, 32, 1, 0.0, output_distribution="nb"
+    ).float()
+    raws: dict[str, torch.Tensor] = {}
+    for head in (1, 2, 3):
+        name = f"dec_conv4_head{head}_reg"
+        dict(model.named_modules())[name].register_forward_hook(
+            lambda _m, _i, out, n=name: raws.__setitem__(n, out.detach())
+        )
+    model.eval()
+    torch.manual_seed(1)
+    x = (torch.rand(1, 3, 32, 32) < 0.03).float() * torch.rand(1, 3, 32, 32) * 4
+    with torch.no_grad():
+        model(x, model.init_hTtime(model.base, 32, 32).float())
+
+    assert raws, "no reg head fired — the hook names are stale"
+    for name, out in raws.items():
+        assert out.min().item() > EDGE, (
+            f"{name}: raw head output reaches {out.min().item():.3f}, below the dead-zone edge "
+            f"{EDGE:.3f}, at INITIALISATION. This finding is no longer latent."
+        )

--- a/tests/distributions/test_gradient_dead_zones.py
+++ b/tests/distributions/test_gradient_dead_zones.py
@@ -55,7 +55,7 @@ EDGE = math.log(math.expm1(_EPS))
 def _grad_wrt_raw(raw_mu: float, raw_theta: float, count: float = 6.0):
     """``dNLL/d(raw)`` through the REAL path, with the target in the space the loss expects.
 
-    Two contracts are easy to get wrong here, and this audit got both wrong once before fixing them:
+    Two contracts are easy to get wrong, and this audit got both wrong once before fixing them:
 
     * ``nll`` receives **activated** params, not raw ones. Passing raw values measures a different
       function entirely and yields a flat, meaningless gradient surface.

--- a/tests/distributions/test_theta_gradient_bound.py
+++ b/tests/distributions/test_theta_gradient_bound.py
@@ -11,6 +11,21 @@ cancelled, so no forward-distorting θ-floor is needed (which would harm the hea
 requires). (At *moderate* θ with an *extreme* count the gradient is legitimately larger — that is
 real heavy-tail signal, not the `1/θ` floor pathology, and the existing global `clip_grad_norm`
 bounds it. That regime is out of C-202's scope.)
+
+TWO CAVEATS ADDED BY THE 2026-08-26 GRADIENT AUDIT (C-313), neither of which invalidates the
+result above:
+
+1. The `raw_theta=-16.0` row is **below** the clamp edge (`softplus(raw) == _EPS` at
+   `raw ≈ -13.8155`), so at that point the bound is met by a gradient of **exactly 0.0** — the
+   channel is dead, not cancelled. The `-10.0` and `-13.0` rows are above the edge and are the
+   ones that actually demonstrate the cancellation this test is named for. The row is kept
+   rather than deleted because it is the evidence that the dead zone exists;
+   `tests/distributions/test_gradient_dead_zones.py` asserts that fact directly.
+
+2. This test, C-202 and its resolution are all about **theta**. The identical clamp applies to
+   **mu**, where `dtheta/d(raw) -> 0` has no counterpart and the head-channel gradient near the
+   floor is approximately the observed count. That is not a defect in this test — it is simply
+   outside its scope, and it is registered separately as C-313.
 """
 
 from __future__ import annotations

--- a/tests/test_falsification_loss_param_validation.py
+++ b/tests/test_falsification_loss_param_validation.py
@@ -30,7 +30,8 @@ class TestF5_CICFieldCountDrift:
         # #287 ss_reverse (Teutsch 2022 ITF, increasing teacher forcing): +ss_reverse -> 90
         # #289 pushforward (Brandstetter 2022): +pushforward_weight,
         # +pushforward_detach_state -> 92
-        CIC_CLAIMED_COUNT = 92
+        # C-314 (training-loop gradient audit): +clip_grad_max_norm -> 93
+        CIC_CLAIMED_COUNT = 93
         actual = len(HydraNetConfig.model_fields)
         assert actual == CIC_CLAIMED_COUNT, (
             f"CIC §3 claims {CIC_CLAIMED_COUNT} fields but HydraNetConfig has {actual}. "

--- a/tests/test_falsification_loss_param_validation.py
+++ b/tests/test_falsification_loss_param_validation.py
@@ -28,7 +28,8 @@ class TestF5_CICFieldCountDrift:
         #   (net +2) -> 88
         # ADR-068 emit_family_core (th_gated_ZINBcore, Epic #167/#183): +emit_family_core -> 89
         # #287 ss_reverse (Teutsch 2022 ITF, increasing teacher forcing): +ss_reverse -> 90
-        CIC_CLAIMED_COUNT = 90
+        # #289 pushforward (Brandstetter 2022): +pushforward_weight, +pushforward_detach_state -> 92
+        CIC_CLAIMED_COUNT = 92
         actual = len(HydraNetConfig.model_fields)
         assert actual == CIC_CLAIMED_COUNT, (
             f"CIC §3 claims {CIC_CLAIMED_COUNT} fields but HydraNetConfig has {actual}. "

--- a/tests/test_falsification_loss_param_validation.py
+++ b/tests/test_falsification_loss_param_validation.py
@@ -28,7 +28,8 @@ class TestF5_CICFieldCountDrift:
         #   (net +2) -> 88
         # ADR-068 emit_family_core (th_gated_ZINBcore, Epic #167/#183): +emit_family_core -> 89
         # #287 ss_reverse (Teutsch 2022 ITF, increasing teacher forcing): +ss_reverse -> 90
-        # #289 pushforward (Brandstetter 2022): +pushforward_weight, +pushforward_detach_state -> 92
+        # #289 pushforward (Brandstetter 2022): +pushforward_weight,
+        # +pushforward_detach_state -> 92
         CIC_CLAIMED_COUNT = 92
         actual = len(HydraNetConfig.model_fields)
         assert actual == CIC_CLAIMED_COUNT, (

--- a/tests/test_reproducibility_gate.py
+++ b/tests/test_reproducibility_gate.py
@@ -103,14 +103,16 @@ def test_training_engine_uses_lock_entropy():
     np.random.seed / torch.manual_seed calls should be replaced.
     """
     import importlib
-    import sys
+    from pathlib import Path
 
-    mod_name = "views_hydranet.train.training_engine"
-    if mod_name in sys.modules:
-        del sys.modules[mod_name]
-
-    mod = importlib.import_module(mod_name)
-    source = open(mod.__file__).read()
+    # This assertion is over the module's SOURCE TEXT, so the module object is irrelevant.
+    # It used to `del sys.modules[...]` first and re-import, which replaced the live
+    # training_engine module for the rest of the session: `train_model.training_loop` kept
+    # referring to the OLD module's globals, so any later test that patched a training_engine
+    # attribute was silently patching an object nothing called. Three tests in
+    # tests/train/test_backward_gate.py failed only in a full-suite run because of it.
+    mod = importlib.import_module("views_hydranet.train.training_engine")
+    source = Path(mod.__file__).read_text()
 
     # Should NOT have manual seed calls
     assert "np.random.seed(" not in source, (

--- a/tests/test_reproducibility_gate.py
+++ b/tests/test_reproducibility_gate.py
@@ -126,6 +126,31 @@ def test_training_engine_uses_lock_entropy():
     assert "lock_entropy" in source, "training_engine.py does not reference lock_entropy"
 
 
+def test_the_live_training_engine_module_is_the_one_training_loop_uses():
+    """Guard on the fix above: no test may leave a stale training_engine in sys.modules.
+
+    ``test_training_engine_uses_lock_entropy`` used to ``del sys.modules[...]`` before
+    re-importing. That swapped the module object for the rest of the session while
+    ``train_model.training_loop`` — already bound — kept using the OLD module's globals. Any later
+    test that patched a ``training_engine`` attribute was then patching an object nothing called,
+    and three tests in ``tests/train/test_backward_gate.py`` failed **only** in full-suite runs.
+
+    Those tests are now written against ``training_loop.__globals__`` and so are immune, which is
+    exactly why this guard is needed: with them hardened, re-introducing the delete breaks nothing
+    and nothing notices. This asserts the invariant directly.
+    """
+    import sys
+
+    from views_hydranet.train.train_model import training_loop
+
+    live = sys.modules["views_hydranet.train.training_engine"]
+    assert training_loop.__globals__ is live.__dict__, (
+        "training_loop is running against a DIFFERENT training_engine module object than the one "
+        "in sys.modules. Something deleted or reloaded the module without rebinding its "
+        "importers; monkeypatching training_engine attributes will silently do nothing."
+    )
+
+
 # ---------------------------------------------------------------------------
 # RED TEST 7: Different seeds produce different results
 # ---------------------------------------------------------------------------

--- a/tests/test_rollout_horizon_config.py
+++ b/tests/test_rollout_horizon_config.py
@@ -42,3 +42,38 @@ def test_rollout_horizon_one_still_constructs(valid_config_dict):
     cfg = dict(valid_config_dict)
     cfg["rollout_horizon"] = 1
     assert HydraNetConfig(**cfg).rollout_horizon == 1
+
+
+# ---------------------------------------------------------------------------
+# #289 pushforward_weight — the same "reject if nothing will read it" guard,
+# for a knob that IS wired but only on the family-head path.
+# ---------------------------------------------------------------------------
+def test_pushforward_weight_without_a_family_head_is_rejected(valid_config_dict):
+    """`_process_sequence` guards the pushforward term on `family is not None`.
+
+    A legacy / point / quantile head with `pushforward_weight > 0` would therefore train with NO
+    pushforward at all and report a clean run — the experiment's premise silently invalid, which
+    is exactly the failure `reject_unwired_rollout_horizon` above exists to prevent.
+    """
+    cfg = dict(valid_config_dict)
+    cfg["output_distribution"] = "standard"
+    cfg["pushforward_weight"] = 0.3
+    with pytest.raises(ValidationError, match="pushforward"):
+        HydraNetConfig(**cfg)
+
+
+def test_pushforward_weight_with_a_family_head_constructs(valid_config_dict):
+    """Green: the combination the flag is FOR must construct cleanly."""
+    cfg = dict(valid_config_dict)
+    cfg["output_distribution"] = "nb"
+    cfg["forecast_composition"] = "soft_gate"  # ADR-069: nb is not self-zeroed, so declare a gate
+    cfg["pushforward_weight"] = 0.3
+    assert HydraNetConfig(**cfg).pushforward_weight == 0.3
+
+
+def test_pushforward_weight_zero_is_allowed_on_any_head(valid_config_dict):
+    """The default must never be the thing that rejects a legacy config."""
+    cfg = dict(valid_config_dict)
+    cfg["output_distribution"] = "standard"
+    cfg["pushforward_weight"] = 0.0
+    assert HydraNetConfig(**cfg).pushforward_weight == 0.0

--- a/tests/train/conftest.py
+++ b/tests/train/conftest.py
@@ -1,0 +1,167 @@
+"""Shared harness for the training-loop gradient tests.
+
+Two vehicles, because the two things under test live at different levels:
+
+* :func:`seq_fixture` — the real ``HydraBNUNet06_LSTM4`` plus a sparse log1p field, for anything
+  that needs ``_process_sequence`` and a genuine autograd graph (BPTT reach, per-parameter
+  gradient health). ``TinyModel`` in the top-level ``tests/conftest.py`` has neither BatchNorm nor
+  a ConvLSTM, so it cannot exercise either.
+* :func:`loop_config` / :func:`loop_handler` — a minimal but *real* end-to-end ``training_loop``
+  vehicle (real ``make()``, real optimizer, real data), for the guards that are inline in
+  ``training_loop`` and therefore unreachable any other way: the gradient clip and the
+  ``if w_loss > 0`` backward gate.
+
+Both were previously private helpers duplicated across test modules
+(``tests/train/test_pushforward.py::_fixture``, ``tests/test_optimization_gate.py``).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+import torch.nn as nn  # noqa: E402
+
+from views_hydranet.architectures.registry import get_architecture  # noqa: E402
+from views_hydranet.distributions import get_family  # noqa: E402
+from views_hydranet.train.training_engine import _SequenceIndices  # noqa: E402
+from views_hydranet.utils.volume_handler import VolumeHandler  # noqa: E402
+
+#: Production target names, so the channel-role accessors resolve the same way they do in a run.
+FEATS = ["lr_sb_best", "lr_ns_best", "lr_os_best"]
+CLS = ["by_sb_best", "by_ns_best", "by_os_best"]
+
+
+class SumLoss(nn.Module):
+    """Stand-in for ``MultiTaskLoss``: a plain sum, so a test reads the real per-task terms.
+
+    Deliberately NOT the real balancer — tests that care about the balancer construct it directly.
+    """
+
+    def forward(self, losses):  # noqa: D102
+        return losses.sum()
+
+
+def make_sequence(*, seed: int = 0, T: int = 6, hw: int = 8, trained_ckpt: str | None = None):
+    """Return ``(x, model, h0, idx, family)`` on the real architecture.
+
+    ``x`` is a ``[1, T, 6, hw, hw]`` log1p-space field with ~3% active cells — sparse like the real
+    grid, because a dense field puts the NB head in a regime it never sees in training.
+    """
+    torch.manual_seed(seed)
+    cfg = {
+        "features": FEATS,
+        "regression_targets": FEATS,
+        "classification_targets": CLS,
+        "static_channels": [],
+    }
+    idx = _SequenceIndices(FEATS + CLS, cfg)
+    model = get_architecture("HydraBNUNet06_LSTM4")(
+        len(FEATS), 32, 1, 0.0, output_distribution="nb"
+    ).float()
+    if trained_ckpt is not None:
+        model.load_state_dict(torch.load(trained_ckpt, map_location="cpu", weights_only=False))
+    model.train()
+    h = model.init_hTtime(model.base, hw, hw).float()
+    n = len(FEATS) + len(CLS)
+    x = (torch.rand(1, T, n, hw, hw) < 0.03).float() * torch.rand(1, T, n, hw, hw) * 4
+    return x, model, h, idx, get_family("nb")
+
+
+@pytest.fixture
+def seq_fixture():
+    """Factory for :func:`make_sequence`, so a test can pick its own seed / length."""
+    return make_sequence
+
+
+def loop_config(**overrides):
+    """A minimal config that drives the REAL ``training_loop`` end to end.
+
+    Small enough to run in seconds, real enough that ``make()`` builds the production
+    architecture, optimizer and losses — which is the only way to reach the guards that are
+    inline in ``training_loop``.
+    """
+    cfg = {
+        "model": "HydraBNUNet06_LSTM4",
+        "base": 16,
+        "input_channels": 6,
+        "total_hidden_channels": 16,
+        "output_channels": 6,
+        "dropout_rate": 0.1,
+        "regression_targets": ["lr_f1", "lr_f2", "lr_f3"],
+        "classification_targets": ["by_f1", "by_f2", "by_f3"],
+        "total_lessons": 2,
+        "windows_per_lesson": 1,
+        "steps": [1],
+        "time_steps": 1,
+        "n_posterior_samples": 1,
+        "np_seed": 42,
+        "torch_seed": 42,
+        "learning_rate": 1e-3,
+        "weight_decay": 1e-2,
+        "window_dim": 8,
+        "weight_init": "xavier_uni",
+        "clip_grad_norm": False,
+        "time_col": "t",
+        "id_col": "i",
+        "spatial_cols": ["y", "x"],
+        "identity_cols": ["t", "i"],
+        "features": ["lr_f1", "lr_f2", "lr_f3", "by_f1", "by_f2", "by_f3"],
+        "row_offset": 0,
+        "col_offset": 0,
+        "height": 8,
+        "width": 8,
+        "min_events": 0,
+        "max_events": 100,
+        "sampling_strategy": "threshold",
+        "slope_ratio": 1.0,
+        "roof_ratio": 1.0,
+        "min_ratio": 0.1,
+        "max_ratio": 0.9,
+        "run_type": "train",
+        "scheduler": "none",
+        "loss_reg": "mse",
+        "loss_class": "focal",
+        "loss_reg_a": 1.0,
+        "loss_reg_c": 1.0,
+        "loss_class_alpha": 0.25,
+        "loss_class_gamma": 2.0,
+        "transformations": {"identity": ["lr_f1", "lr_f2", "lr_f3"]},
+        "derivations": {
+            "binary": [
+                {"from": "lr_f1", "to": "by_f1", "threshold": 0},
+                {"from": "lr_f2", "to": "by_f2", "threshold": 0},
+                {"from": "lr_f3", "to": "by_f3", "threshold": 0},
+            ]
+        },
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def loop_handler(cfg, *, seed: int = 0):
+    """A ``VolumeHandler`` carrying enough signal that the losses are non-trivial."""
+    rng = np.random.default_rng(seed)
+    data = rng.random((5, 8, 8, 4))
+    data[..., 1:] = 1.0
+    return VolumeHandler(
+        data=data,
+        axes=("T", "H", "W", "C"),
+        channel_map=["t", "lr_f1", "lr_f2", "lr_f3"],
+        time_col="t",
+        id_col="i",
+        spatial_cols=["y", "x"],
+        identity_cols=["t", "i"],
+        feature_cols=["lr_f1", "lr_f2", "lr_f3"],
+        config=cfg,
+    )
+
+
+def grad_norm(params) -> float:
+    """L2 norm of the concatenated gradient over ``params`` (skipping ``None``)."""
+    total = 0.0
+    for p in params:
+        if p.grad is not None:
+            total += p.grad.detach().norm(2).item() ** 2
+    return total**0.5

--- a/tests/train/test_backward_gate.py
+++ b/tests/train/test_backward_gate.py
@@ -105,8 +105,15 @@ def test_the_sign_boundary_is_where_the_task_loss_falls_below_one_over_e(loss, e
     )
 
 
-def _run_lessons(*, freeze: bool, lessons: int, pin_log_vars: bool, caplog=None):
-    """Drive the real ``training_loop`` and count how many lessons actually produced an update."""
+def _run_lessons(*, freeze: bool, lessons: int, pin_log_vars: bool, count_backwards: bool = False):
+    """Drive the real ``training_loop``; count optimizer updates, or backward passes.
+
+    ``count_backwards`` counts gradient *accumulations* on a single parameter via a
+    post-accumulate-grad hook. That is the only way to observe the ``if w_loss > 0`` guard at
+    ``:1015`` on its own: the ``if lesson_loss > 0`` guard at ``:1027`` independently suppresses
+    the optimizer step, so counting steps cannot distinguish the two. Removing the backward guard
+    alone left an earlier version of this file entirely green.
+    """
     cfg = loop_config(
         clip_grad_norm=True,
         freeze_multitask_balancer=freeze,
@@ -125,11 +132,36 @@ def _run_lessons(*, freeze: bool, lessons: int, pin_log_vars: bool, caplog=None)
         with torch.no_grad():
             balancer.log_vars.copy_(torch.log(raw / (balancer.is_regression + 1.0)))
 
-    steps: list[int] = []
-    original_step = optimizer.step
-    optimizer.step = lambda *a, **k: (steps.append(1), original_step(*a, **k))[1]
+    events: list[int] = []
+    if count_backwards:
+        probe = next(p for p in model.parameters() if p.requires_grad)
+        probe.register_post_accumulate_grad_hook(lambda _p: events.append(1))
+    else:
+        original_step = optimizer.step
+        optimizer.step = lambda *a, **k: (events.append(1), original_step(*a, **k))[1]
     training_loop(cfg, model, criterion, optimizer, scheduler, loop_handler(cfg), device)
-    return len(steps)
+    return len(events)
+
+
+def test_the_backward_guard_itself_stops_firing_not_just_the_optimizer_step():
+    """Isolates the ``if w_loss > 0`` guard from the ``if lesson_loss > 0`` guard below it.
+
+    Counts gradient accumulations rather than optimizer steps. With the frozen balancer every
+    window backpropagates; with the balancer at its fixed point most windows do not, and the
+    compute spent on those forward passes is discarded.
+
+    This test exists because a mutation that deleted the backward guard entirely — leaving only
+    the lesson-level guard — passed every other test in this file.
+    """
+    frozen = _run_lessons(freeze=True, lessons=6, pin_log_vars=False, count_backwards=True)
+    active = _run_lessons(freeze=False, lessons=6, pin_log_vars=True, count_backwards=True)
+    assert frozen == 6, (
+        f"the frozen control backpropagated {frozen} times, expected one per lesson"
+    )
+    assert active < frozen, (
+        f"the active balancer still backpropagated {active} times out of {frozen}: the guard at "
+        "training_engine.py:1015 is no longer skipping non-positive windows."
+    )
 
 
 def test_the_frozen_balancer_trains_every_lesson():

--- a/tests/train/test_backward_gate.py
+++ b/tests/train/test_backward_gate.py
@@ -21,15 +21,20 @@ Measured (2026-08-26), per task, ``term(L, v) = L / ((r+1) e^v) + v/2``. Minimis
 That is not an exotic regime; it is what a well-fitted task looks like. A balancer that converges
 therefore drives the total negative and silently switches training off.
 
-**Production is not currently exposed**: every live arm config sets
-``freeze_multitask_balancer: True``, which keeps ``log_vars`` pinned at 0 (``log(stds) = 0``, all
-terms non-negative). But the config default is ``False``, so the exposure is one forgotten line
-away. These tests pin the mechanism and the boundary.
+**Production was never exposed**: every live arm config sets ``freeze_multitask_balancer: True``,
+which keeps ``log_vars`` pinned at 0 (``log(stds) = 0``, all terms non-negative). But the config
+default is ``False``, so the exposure was one forgotten line away.
+
+**FIXED (C-312).** The guards now ask the question ADR-014 means to ask — *did this window have
+anything to learn from?* — rather than testing a sign. A window backpropagates unless its loss is
+exactly zero; a non-finite loss raises instead of being skipped; and the optimization gate keys on
+whether any window actually produced gradient. Measured on the same vehicle: **6 updates across 6
+lessons**, where the old guards gave 2. Under the frozen balancer the old and new predicates select
+identically, so no existing result moves — proved by
+:func:`test_the_new_guard_is_byte_identical_when_frozen` rather than asserted.
 """
 
 from __future__ import annotations
-
-import logging
 
 import pytest
 
@@ -143,66 +148,137 @@ def _run_lessons(*, freeze: bool, lessons: int, pin_log_vars: bool, count_backwa
     return len(events)
 
 
-def test_the_backward_guard_itself_stops_firing_not_just_the_optimizer_step():
-    """Isolates the ``if w_loss > 0`` guard from the ``if lesson_loss > 0`` guard below it.
+def test_the_backward_guard_fires_on_every_window_that_has_data():
+    """C-312 regression: an active balancer must no longer suppress backward passes.
 
-    Counts gradient accumulations rather than optimizer steps. With the frozen balancer every
-    window backpropagates; with the balancer at its fixed point most windows do not, and the
-    compute spent on those forward passes is discarded.
+    Counts gradient accumulations rather than optimizer steps, because the optimization gate is a
+    *second*, independent guard — counting steps cannot see this one. (A mutation deleting the
+    backward guard passed every other test in this file until this was added.)
 
-    This test exists because a mutation that deleted the backward guard entirely — leaving only
-    the lesson-level guard — passed every other test in this file.
+    Pre-fix this vehicle backpropagated on 2 of 6 windows with the balancer at its fixed point.
     """
     frozen = _run_lessons(freeze=True, lessons=6, pin_log_vars=False, count_backwards=True)
     active = _run_lessons(freeze=False, lessons=6, pin_log_vars=True, count_backwards=True)
     assert frozen == 6, (
         f"the frozen control backpropagated {frozen} times, expected one per lesson"
     )
-    assert active < frozen, (
-        f"the active balancer still backpropagated {active} times out of {frozen}: the guard at "
-        "training_engine.py:1015 is no longer skipping non-positive windows."
+    assert active == frozen, (
+        f"the active balancer backpropagated {active} times out of {frozen}: a negative total is "
+        "suppressing backward again (C-312)."
     )
 
 
-def test_the_frozen_balancer_trains_every_lesson():
-    """Control: production (``freeze_multitask_balancer: True``) updates once per lesson."""
-    assert _run_lessons(freeze=True, lessons=6, pin_log_vars=False) == 6, (
-        "the frozen-balancer control no longer trains every lesson — the comparison below is void"
-    )
+def test_an_active_balancer_no_longer_stops_training_partway_through_the_run():
+    """C-312 regression, at the level that matters: every lesson still updates the weights.
 
-
-def test_an_active_balancer_silently_stops_training_partway_through_the_run(caplog):
-    """CHARACTERISATION, and the finding: the run keeps going, the model stops learning.
-
-    Same vehicle, same seed, same number of lessons — only the balancer differs. With
-    ``log_vars`` at the balancer's own fixed point, the total goes negative after a couple of
-    lessons, ``if w_loss > 0`` stops calling ``backward()`` and ``if lesson_loss > 0`` stops
-    calling ``optimizer.step()``. Measured here: **2 updates out of 6 lessons**, versus 6 of 6
-    for the frozen control.
-
-    Nothing above DEBUG is logged when this happens, which is the part that makes it dangerous:
-    the progress bar advances, the loss curve is written, wandb receives rows, and the run looks
-    healthy from the outside.
-
-    Not currently reachable in production — every live arm config pins
-    ``freeze_multitask_balancer: True``. But the *config default is* ``False``
-    (``config_initializer.py:274``), so a new arm config that omits the line gets this regime.
+    Same vehicle, same seed, only the balancer differs. Pre-fix: 2 updates across 6 lessons, with
+    nothing logged — the run looked healthy from the outside while the model had stopped learning.
     """
     lessons = 6
-    with caplog.at_level(logging.DEBUG):
-        updates = _run_lessons(freeze=False, lessons=lessons, pin_log_vars=True)
+    updates = _run_lessons(freeze=False, lessons=lessons, pin_log_vars=True)
+    assert updates == lessons, (
+        f"only {updates} of {lessons} lessons produced an update. The optimization gate is keying "
+        "on the sign of the accumulated loss again (C-312)."
+    )
 
-    assert updates < lessons, (
-        f"all {lessons} lessons produced an update — the total never went non-positive, so this "
-        "characterisation no longer reproduces. Re-measure MEASURED_TASK_LOSSES."
+
+def test_the_new_guard_is_byte_identical_when_frozen():
+    """The C-112 comparability proof: under production config the two predicates cannot differ.
+
+    C-112 records that changing training dynamics makes pre/post-fix model metrics incomparable,
+    so this fix is only safe if it is a no-op on the configuration every existing result was
+    produced under. With ``freeze_multitask_balancer: True`` the balancer contributes
+    ``log(stds) = 0`` and every task term is non-negative, so ``w_loss >= 0`` always and the old
+    ``> 0`` and new ``!= 0`` select the same windows.
+
+    Asserted by observing every window's total during a real run rather than by re-deriving the
+    algebra, so it stays true if the loss composition changes.
+    """
+    cfg = loop_config(
+        clip_grad_norm=True, freeze_multitask_balancer=True, total_lessons=4, bn_recalibrate=False
     )
-    complaints = [
-        r.getMessage()
-        for r in caplog.records
-        if r.levelno >= logging.WARNING
-        and any(w in r.getMessage().lower() for w in ("skip", "negative", "non-positive"))
-    ]
-    assert not complaints, (
-        f"{lessons - updates} lessons were skipped and something now warns about it — good, but "
-        f"this test documented the SILENCE. Update it deliberately. Got: {complaints[:3]}"
+    device = torch.device("cpu")
+    torch.manual_seed(cfg["torch_seed"])
+    model, criterion, optimizer, scheduler = make(cfg, device)
+
+    totals: list[float] = []
+    original_train = training_loop.__globals__["train"]
+
+    def spy(ctx, handler, pbar, **kwargs):
+        result = original_train(ctx, handler, pbar, **kwargs)
+        totals.append(result["total"].item())
+        return result
+
+    training_loop.__globals__["train"] = spy
+    try:
+        training_loop(cfg, model, criterion, optimizer, scheduler, loop_handler(cfg), device)
+    finally:
+        training_loop.__globals__["train"] = original_train
+
+    assert totals, "no windows ran — the vehicle did not train"
+    assert all(t >= 0.0 for t in totals), (
+        f"a frozen-balancer window scored below zero (min {min(totals):.6f}). The equal-weighting "
+        "regime no longer guarantees a non-negative total, so this fix is NOT a no-op on the "
+        "configuration every existing result was produced under — stop and re-derive."
     )
+    disagreements = [t for t in totals if (t > 0.0) != (t != 0.0)]
+    assert not disagreements, (
+        f"old predicate (> 0) and new predicate (!= 0) disagree on {len(disagreements)} windows: "
+        f"{disagreements[:3]}"
+    )
+
+
+def test_an_empty_window_still_skips_backward():
+    """ADR-014's actual intent survives the fix: a zero loss means no supervised cells, so no step.
+
+    Guards against 'fixing' C-312 by simply always backpropagating, which would spend a full
+    backward pass on windows with nothing in them.
+    """
+    cfg = loop_config(freeze_multitask_balancer=True, total_lessons=1, bn_recalibrate=False)
+    device = torch.device("cpu")
+    torch.manual_seed(cfg["torch_seed"])
+    model, criterion, optimizer, scheduler = make(cfg, device)
+
+    original_train = training_loop.__globals__["train"]
+
+    def zero_loss(ctx, handler, pbar, **kwargs):
+        result = original_train(ctx, handler, pbar, **kwargs)
+        result["total"] = torch.zeros((), requires_grad=True)
+        return result
+
+    training_loop.__globals__["train"] = zero_loss
+    steps: list[int] = []
+    original_step = optimizer.step
+    optimizer.step = lambda *a, **k: (steps.append(1), original_step(*a, **k))[1]
+    try:
+        training_loop(cfg, model, criterion, optimizer, scheduler, loop_handler(cfg), device)
+    finally:
+        training_loop.__globals__["train"] = original_train
+
+    assert not steps, "an all-zero (empty) window still triggered an optimizer step"
+
+
+def test_a_non_finite_loss_raises_instead_of_being_skipped():
+    """A NaN loss used to fail ``w_loss > 0`` and be silently skipped like an empty window.
+
+    Silently discarding a NaN window hides the upstream bug that produced it — C-212 was exactly
+    such a bug — so the fix raises rather than skipping.
+    """
+    cfg = loop_config(freeze_multitask_balancer=True, total_lessons=1, bn_recalibrate=False)
+    device = torch.device("cpu")
+    torch.manual_seed(cfg["torch_seed"])
+    model, criterion, optimizer, scheduler = make(cfg, device)
+
+    original_train = training_loop.__globals__["train"]
+
+    def nan_loss(ctx, handler, pbar, **kwargs):
+        result = original_train(ctx, handler, pbar, **kwargs)
+        result["total"] = torch.tensor(float("nan"), requires_grad=True)
+        return result
+
+    training_loop.__globals__["train"] = nan_loss
+    try:
+        with pytest.raises(ValueError, match="not a finite number"):
+            training_loop(cfg, model, criterion, optimizer, scheduler, loop_handler(cfg), device)
+    finally:
+        training_loop.__globals__["train"] = original_train

--- a/tests/train/test_backward_gate.py
+++ b/tests/train/test_backward_gate.py
@@ -1,0 +1,176 @@
+"""The ``if w_loss > 0`` gate on ``backward()`` — what it costs when the total goes negative.
+
+``training_engine.py:1015`` guards the only ``backward()`` in the package::
+
+    if w_loss > 0 and not _bn_recal:
+        w_loss.backward()
+
+and ``:1027`` guards the optimizer step the same way (``if lesson_loss > 0``). Read as
+"skip empty windows" that is ADR-014's intent and it is correct. But ``w_loss`` comes from
+``MultiTaskLoss``, whose ``forward`` returns::
+
+    coeffs * losses + torch.log(stds + eps)
+
+and ``log(stds)`` is **negative whenever ``log_var < 0``**. So the guard is not testing
+"is there anything to learn from" — it is testing the sign of a quantity the balancer can drive
+negative. When it does, the window's ``backward()`` is skipped with no warning, no log line and
+no counter: the run keeps going and simply stops learning.
+
+Measured (2026-08-26), per task, ``term(L, v) = L / ((r+1) e^v) + v/2``. Minimised over ``v`` at
+``e^v = L/(r+1)``, giving ``term = 1/2 + log(L/(r+1))/2`` — **negative once ``L < (r+1)/e``**.
+That is not an exotic regime; it is what a well-fitted task looks like. A balancer that converges
+therefore drives the total negative and silently switches training off.
+
+**Production is not currently exposed**: every live arm config sets
+``freeze_multitask_balancer: True``, which keeps ``log_vars`` pinned at 0 (``log(stds) = 0``, all
+terms non-negative). But the config default is ``False``, so the exposure is one forgotten line
+away. These tests pin the mechanism and the boundary.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from views_hydranet.train.train_model import make, training_loop  # noqa: E402
+from views_hydranet.utils.mtloss import MultiTaskLoss  # noqa: E402
+
+from .conftest import loop_config, loop_handler  # noqa: E402
+
+#: 3 regression + 3 classification, the production task layout.
+IS_REG = [1.0, 1.0, 1.0, 0.0, 0.0, 0.0]
+
+#: Per-task losses measured on the ``loop_config`` vehicle (2026-08-26), used only to place
+#: ``log_vars`` at the balancer's fixed point without waiting for it to descend there.
+MEASURED_TASK_LOSSES = [0.615, 0.643, 0.919, 0.0363, 0.0291, 0.0891]
+
+
+def _balancer(log_vars=None):
+    m = MultiTaskLoss(torch.tensor(IS_REG), reduction="sum")
+    if log_vars is not None:
+        with torch.no_grad():
+            m.log_vars.copy_(torch.tensor(log_vars, dtype=m.log_vars.dtype))
+    return m
+
+
+def test_frozen_balancer_keeps_every_term_non_negative():
+    """The production regime: ``log_vars == 0`` ⇒ ``log(stds) == 0`` ⇒ the guard is honest.
+
+    This is why the finding below is latent rather than active, and it is the thing that would
+    silently stop being true if the freeze flag were dropped from a config.
+    """
+    m = _balancer()
+    assert torch.equal(m.log_vars, torch.zeros(6)), "log_vars no longer initialise to zero"
+    for losses in ([1.0] * 6, [0.1] * 6, [1e-4] * 6):
+        total = m(torch.tensor(losses))
+        assert total >= 0.0, (
+            f"frozen balancer produced a negative total {total.item()} for {losses}"
+        )
+    assert m(torch.zeros(6)).item() == 0.0, "an all-zero window should score exactly 0"
+
+
+def test_an_active_balancer_can_drive_the_total_negative():
+    """The mechanism. A well-fitted task at its own optimal ``log_var`` contributes < 0.
+
+    Uses the analytic optimum ``v* = log(L/(r+1))`` rather than a hand-picked number, so the test
+    states the property (converged balancer ⇒ negative total) instead of a magic constant.
+    """
+    loss = 0.05  # a well-fitted task
+    opt_v = [torch.log(torch.tensor(loss / (r + 1.0))).item() for r in IS_REG]
+    m = _balancer(opt_v)
+    total = m(torch.full((6,), loss))
+    assert total.item() < 0.0, (
+        f"expected a negative total at the balancer optimum, got {total.item():.4f}. "
+        "MultiTaskLoss no longer adds log(stds); re-derive this test."
+    )
+
+
+@pytest.mark.parametrize("loss,expect_negative", [(0.05, True), (0.2, True), (1.0, False)])
+def test_the_sign_boundary_is_where_the_task_loss_falls_below_one_over_e(loss, expect_negative):
+    """Pins WHERE the flip happens: a regression task's term goes negative for ``L < 2/e ≈ 0.736``.
+
+    Recomputed from the closed form rather than asserted from a table, so a change to the
+    ``(is_regression + 1)`` weighting or the ``log(stds)`` term is caught here.
+    """
+    v = torch.log(torch.tensor(loss / 2.0)).item()  # optimum for a regression task (r = 1)
+    m = MultiTaskLoss(torch.tensor([1.0]), reduction="sum")
+    with torch.no_grad():
+        m.log_vars.copy_(torch.tensor([v]))
+    term = m(torch.tensor([loss])).item()
+    assert (term < 0.0) is expect_negative, (
+        f"loss={loss}: term={term:.4f}, expected negative={expect_negative}"
+    )
+
+
+def _run_lessons(*, freeze: bool, lessons: int, pin_log_vars: bool, caplog=None):
+    """Drive the real ``training_loop`` and count how many lessons actually produced an update."""
+    cfg = loop_config(
+        clip_grad_norm=True,
+        freeze_multitask_balancer=freeze,
+        total_lessons=lessons,
+        bn_recalibrate=False,  # the BN-recal pass is forward-only; excluded so the count is clean
+    )
+    device = torch.device("cpu")
+    torch.manual_seed(cfg["torch_seed"])
+    model, criterion, optimizer, scheduler = make(cfg, device)
+    balancer = criterion[2]
+
+    if pin_log_vars:
+        # The balancer's own fixed point for this vehicle's measured task losses:
+        # v* = log(L / (r + 1)). Descent moves toward here; starting here just skips the wait.
+        raw = torch.tensor(MEASURED_TASK_LOSSES)
+        with torch.no_grad():
+            balancer.log_vars.copy_(torch.log(raw / (balancer.is_regression + 1.0)))
+
+    steps: list[int] = []
+    original_step = optimizer.step
+    optimizer.step = lambda *a, **k: (steps.append(1), original_step(*a, **k))[1]
+    training_loop(cfg, model, criterion, optimizer, scheduler, loop_handler(cfg), device)
+    return len(steps)
+
+
+def test_the_frozen_balancer_trains_every_lesson():
+    """Control: production (``freeze_multitask_balancer: True``) updates once per lesson."""
+    assert _run_lessons(freeze=True, lessons=6, pin_log_vars=False) == 6, (
+        "the frozen-balancer control no longer trains every lesson — the comparison below is void"
+    )
+
+
+def test_an_active_balancer_silently_stops_training_partway_through_the_run(caplog):
+    """CHARACTERISATION, and the finding: the run keeps going, the model stops learning.
+
+    Same vehicle, same seed, same number of lessons — only the balancer differs. With
+    ``log_vars`` at the balancer's own fixed point, the total goes negative after a couple of
+    lessons, ``if w_loss > 0`` stops calling ``backward()`` and ``if lesson_loss > 0`` stops
+    calling ``optimizer.step()``. Measured here: **2 updates out of 6 lessons**, versus 6 of 6
+    for the frozen control.
+
+    Nothing above DEBUG is logged when this happens, which is the part that makes it dangerous:
+    the progress bar advances, the loss curve is written, wandb receives rows, and the run looks
+    healthy from the outside.
+
+    Not currently reachable in production — every live arm config pins
+    ``freeze_multitask_balancer: True``. But the *config default is* ``False``
+    (``config_initializer.py:274``), so a new arm config that omits the line gets this regime.
+    """
+    lessons = 6
+    with caplog.at_level(logging.DEBUG):
+        updates = _run_lessons(freeze=False, lessons=lessons, pin_log_vars=True)
+
+    assert updates < lessons, (
+        f"all {lessons} lessons produced an update — the total never went non-positive, so this "
+        "characterisation no longer reproduces. Re-measure MEASURED_TASK_LOSSES."
+    )
+    complaints = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno >= logging.WARNING
+        and any(w in r.getMessage().lower() for w in ("skip", "negative", "non-positive"))
+    ]
+    assert not complaints, (
+        f"{lessons - updates} lessons were skipped and something now warns about it — good, but "
+        f"this test documented the SILENCE. Update it deliberately. Got: {complaints[:3]}"
+    )

--- a/tests/train/test_backward_gate.py
+++ b/tests/train/test_backward_gate.py
@@ -262,7 +262,8 @@ def test_a_non_finite_loss_raises_instead_of_being_skipped():
     """A NaN loss used to fail ``w_loss > 0`` and be silently skipped like an empty window.
 
     Silently discarding a NaN window hides the upstream bug that produced it — C-212 was exactly
-    such a bug — so the fix raises rather than skipping.
+    such a bug — so the fix raises rather than skipping. ``RuntimeError`` to match
+    ``IntegrityGuardian.monitor``, which raises on the same condition twenty lines further down.
     """
     cfg = loop_config(freeze_multitask_balancer=True, total_lessons=1, bn_recalibrate=False)
     device = torch.device("cpu")
@@ -278,7 +279,7 @@ def test_a_non_finite_loss_raises_instead_of_being_skipped():
 
     training_loop.__globals__["train"] = nan_loss
     try:
-        with pytest.raises(ValueError, match="not a finite number"):
+        with pytest.raises(RuntimeError, match="not a finite number"):
             training_loop(cfg, model, criterion, optimizer, scheduler, loop_handler(cfg), device)
     finally:
         training_loop.__globals__["train"] = original_train

--- a/tests/train/test_bptt_reach.py
+++ b/tests/train/test_bptt_reach.py
@@ -1,0 +1,147 @@
+"""How far back in time gradient actually travels — and that nothing truncates it.
+
+There is **no BPTT truncation anywhere in the package**. ``training_engine.py:350`` rebinds the
+recurrent state with no ``detach``::
+
+    t1_pred, t1_pred_class, h = output.reg, output.cls, output.h_next
+
+``total_loss += loss`` accumulates every step, and there is exactly one ``.backward()`` in the
+whole codebase (``:1016``), called once per *window* over all ``seq_len - 1`` steps. No
+``retain_graph``, no ``torch.utils.checkpoint``, no chunking. ``VolumeSampler._generate_window``
+slices space only, so ``seq_len`` is the full training time axis — ~383 steps in a production run.
+
+That is a deliberate design with a real cost (the whole graph is resident until backward), and
+nothing tested it. Worse, nothing measured whether the reach is *used*: ``max_raw_grad_norm``
+(``:1053-1060``) only watches for explosion, never for vanishing.
+
+**Measured 2026-08-26**, ``d||h_final||^2 / dx_i`` at T=120 — frame ``i`` can reach ``h_final``
+only through memory, so this isolates the recurrent path from each frame's own forward step:
+
+===================  ==================  =====================
+steps back           random init         trained L=300 incumbent
+===================  ==================  =====================
+0                    1.14e+01            5.56e+01
+20                   1.40e-03            3.94e+00
+60                   2.98e-09            2.65e-01
+118                  2.81e-17            1.56e-02
+===================  ==================  =====================
+
+Two things follow. The untrained recurrence is sharply contractive and geometric — the
+``MillerHardt2019`` stable regime, where a truncated feed-forward model would approximate it and
+the memory is decorative. **Training escapes that regime**: the trained decay is sub-exponential
+and retains ~1e14 times more gradient at 118 steps back. So the full BPTT graph is *not*
+decorative, and the M46 ``WideMemory`` null is **not** explained by gradient failing to reach the
+recurrence. Whatever caps that arm, it is not vanishing gradient.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+import torch.nn as nn  # noqa: E402
+
+from views_hydranet.distributions.family_loss import FamilyLoss  # noqa: E402
+from views_hydranet.train.training_engine import _process_sequence  # noqa: E402
+
+from .conftest import SumLoss, make_sequence  # noqa: E402
+
+
+def _recurrent_reach(T: int, hw: int = 12, seed: int = 3):
+    """``d||h_final||^2 / dx_i`` per input frame — the pure memory path.
+
+    Deliberately NOT ``d(total_loss)/dx_i``: every frame is also the direct input to its own step,
+    so that quantity is dominated by the feed-forward path and says nothing about memory.
+    """
+    x, model, h0, idx, family = make_sequence(seed=seed, T=T, hw=hw)
+    x = x.detach().requires_grad_(True)
+    out = _process_sequence(
+        x,
+        model,
+        h0,
+        criterion_reg=FamilyLoss(family),
+        criterion_class=nn.BCEWithLogitsLoss(),
+        multitaskloss_instance=SumLoss(),
+        idx=idx,
+        device=torch.device("cpu"),
+        family=family,
+        ss_feedback="mean",
+        forecast_composition="soft_gate",
+    )
+    (grad,) = torch.autograd.grad((out["h"] ** 2).sum(), x)
+    return grad[0].flatten(1).norm(dim=1)
+
+
+def test_the_recurrence_is_never_truncated():
+    """The FIRST frame must still influence the LAST hidden state.
+
+    This is the guard on the untruncated design. Inserting a ``.detach()`` anywhere in the state
+    carry — the single most plausible "optimisation" someone reaches for when this graph runs out
+    of memory — zeroes the early frames and fails here.
+    """
+    norms = _recurrent_reach(T=24)
+    assert norms[0].item() > 0.0, (
+        "frame 0 has NO gradient path to the final hidden state: the recurrence is being "
+        "truncated. If that was intentional, this test is the place to say so."
+    )
+    dead = (norms[:-1] == 0).nonzero().flatten().tolist()
+    assert not dead, f"frames with a severed gradient path to h_final: {dead}"
+
+
+def test_gradient_survives_far_enough_back_to_justify_the_full_graph():
+    """The reach must be long, or the untruncated graph is paying memory for nothing.
+
+    Threshold set two orders below the measured value at this length, so it catches a regime
+    change (a return to the contractive random-init behaviour, which is ~1e-17 at 118 steps) and
+    not ordinary seed-to-seed variation.
+    """
+    T = 40
+    norms = _recurrent_reach(T=T)
+    ratio = (norms[0] / norms[T - 2]).item()
+    assert ratio > 1e-9, (
+        f"gradient at {T - 2} steps back is {ratio:.3e} of the immediate one. The recurrence has "
+        "collapsed into the strongly contractive regime, where truncated BPTT would be free and "
+        "the memory is decorative. That is a finding, not a flaky test — investigate."
+    )
+
+
+def test_reach_decays_monotonically_with_distance():
+    """Sanity on the measurement itself: further back must not carry MORE gradient.
+
+    Compares block means rather than adjacent frames, because per-frame values are noisy in the
+    sparse field; a violation here means the probe is measuring something other than reach.
+    """
+    norms = _recurrent_reach(T=40)
+    near = norms[-6:-1].mean().item()  # closest to the end
+    far = norms[:5].mean().item()  # the very start of the sequence
+    assert far < near, (
+        f"early frames ({far:.4e}) carry more gradient to h_final than late ones ({near:.4e}); "
+        "the reach probe is not measuring the recurrent path"
+    )
+
+
+def test_the_whole_sequence_is_one_graph_not_per_step_backwards():
+    """One graph, one backward. A per-step ``backward()`` would free the graph and raise here.
+
+    ``_process_sequence`` returns a ``total`` that must still be differentiable across the entire
+    sequence; calling backward twice without ``retain_graph`` is how we detect that the returned
+    scalar is a live accumulation rather than a detached sum of already-freed pieces.
+    """
+    x, model, h0, idx, family = make_sequence(seed=5, T=8, hw=8)
+    out = _process_sequence(
+        x,
+        model,
+        h0,
+        criterion_reg=FamilyLoss(family),
+        criterion_class=nn.BCEWithLogitsLoss(),
+        multitaskloss_instance=SumLoss(),
+        idx=idx,
+        device=torch.device("cpu"),
+        family=family,
+        ss_feedback="mean",
+        forecast_composition="soft_gate",
+    )
+    assert out["total"].requires_grad, "the accumulated total is detached — nothing can train"
+    out["total"].backward()
+    with pytest.raises(RuntimeError, match="second time|freed"):
+        out["total"].backward()

--- a/tests/train/test_gradient_health.py
+++ b/tests/train/test_gradient_health.py
@@ -1,0 +1,201 @@
+"""Gradient health of the real training path — the checks the suite did not have.
+
+Audit finding (2026-08-26). Before this file:
+
+* **No test asserted that every parameter receives gradient.** The two that came closest use
+  ``any(...)`` (``test_scheduled_sampling.py``, ``test_optimization_gate.py::test_gate_18``); a
+  dead regression head, a disconnected LSTM gate or a severed encoder branch passed the whole
+  suite.
+* **``clip_grad_norm_`` had no behavioural coverage at all.** Deleting the call at
+  ``training_engine.py:1079-1080`` passed 1630 tests. ``max_norm=1.0`` is hardcoded there while
+  the ``clip_grad_norm`` config field is a *bool*, so the only thing the config can say is
+  on/off — and nothing checked that "on" did anything.
+
+The clip is inline in ``training_loop``, so the only honest way to test it is to drive the real
+loop and observe the gradient the optimizer is actually handed. That is what these tests do.
+
+Measured on this vehicle at the time of writing: raw gradient norm **5.678 / 5.614** across the
+two lessons, clipped norm **exactly 1.0000**. The gap is what makes the assertions discriminating.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+import torch.nn as nn  # noqa: E402
+
+from views_hydranet.distributions.family_loss import FamilyLoss  # noqa: E402
+from views_hydranet.train.train_model import make, training_loop  # noqa: E402
+from views_hydranet.train.training_engine import _process_sequence  # noqa: E402
+
+from .conftest import SumLoss, grad_norm, loop_config, loop_handler, make_sequence  # noqa: E402
+
+
+def _norms_at_step(clip: bool):
+    """Run the real ``training_loop`` and record the gradient norm as the optimizer sees it.
+
+    The spy wraps ``optimizer.step`` rather than ``clip_grad_norm_`` deliberately: patching the
+    clip would test that we call a function, and this needs to test that the gradient reaching the
+    update is actually bounded. A mutation that deletes the clip call is invisible to the former
+    and fatal to the latter.
+    """
+    cfg = loop_config(clip_grad_norm=clip)
+    device = torch.device("cpu")
+    torch.manual_seed(cfg["torch_seed"])
+    model, criterion, optimizer, scheduler = make(cfg, device)
+    handler = loop_handler(cfg)
+
+    seen: list[float] = []
+    original_step = optimizer.step
+
+    def spy(*args, **kwargs):
+        seen.append(grad_norm(model.parameters()))
+        return original_step(*args, **kwargs)
+
+    optimizer.step = spy
+    training_loop(cfg, model, criterion, optimizer, scheduler, handler, device)
+    return seen
+
+
+def test_clip_grad_norm_true_actually_bounds_the_gradient():
+    """``clip_grad_norm: True`` must leave the optimizer a gradient of norm <= 1.0.
+
+    Kills both the "delete the clip" mutation and the "raise max_norm" mutation: the unclipped
+    norm on this vehicle is ~5.6, so any max_norm above ~5.6 — or no clip at all — fails here.
+    """
+    norms = _norms_at_step(clip=True)
+    assert norms, "optimizer.step was never called — the vehicle did not train"
+    for i, n in enumerate(norms):
+        assert n == pytest.approx(1.0, abs=1e-4), (
+            f"lesson {i}: gradient norm at optimizer.step is {n:.4f}, not the clipped 1.0. "
+            "Either clip_grad_norm_ is not being called, or its max_norm is no longer 1.0."
+        )
+
+
+def test_clip_grad_norm_false_leaves_the_gradient_alone():
+    """The off switch must really be off, or 'clipped' and 'unclipped' arms are one run.
+
+    Pins the measured unclipped magnitude (~5.6) well above 1.0, which is also what makes the
+    test above able to tell clipping from not-clipping.
+    """
+    norms = _norms_at_step(clip=False)
+    assert norms, "optimizer.step was never called — the vehicle did not train"
+    for i, n in enumerate(norms):
+        assert n > 2.0, (
+            f"lesson {i}: unclipped gradient norm is {n:.4f}. The vehicle no longer produces a "
+            "gradient large enough for the clip tests to discriminate; re-measure and re-tune."
+        )
+
+
+def test_the_balancer_log_vars_are_NOT_clipped_characterisation():
+    """CHARACTERISATION of current behaviour — the clip covers ``model.parameters()`` only.
+
+    ``MultiTaskLoss.log_vars`` is added to the optimizer as its own param group (C-111,
+    ``training_engine.py:130-133``) but is not part of ``model.parameters()``, so neither the
+    ``clip_grad_norm_`` call nor the ``max_raw_grad_norm`` explosion audit above it can see it.
+    ``coeffs = 1 / ((is_regression + 1) * stds**2 + eps)`` has no upper bound, so an unclipped
+    ``log_vars`` is an unbounded amplifier on every task loss.
+
+    This asserts the *current* behaviour by running the exact clip call the training loop makes
+    and showing a large ``log_vars`` gradient survives it untouched. Fixing this would change
+    training dynamics (C-112), so the fix must break this test deliberately, not silently.
+    """
+    cfg = loop_config(clip_grad_norm=True, freeze_multitask_balancer=False)
+    device = torch.device("cpu")
+    torch.manual_seed(cfg["torch_seed"])
+    model, criterion, optimizer, _scheduler = make(cfg, device)
+    balancer = criterion[2]
+
+    log_vars = next(iter(balancer.parameters()))
+    assert id(log_vars) not in {id(p) for p in model.parameters()}, (
+        "log_vars are now inside model.parameters(); the clip DOES cover them and this "
+        "characterisation is obsolete — delete it."
+    )
+    assert id(log_vars) in {id(p) for g in optimizer.param_groups for p in g["params"]}, (
+        "log_vars are not in the optimizer, so C-111's active balancer is not wired up"
+    )
+
+    # Give both the model and the balancer a gradient far above max_norm=1.0 ...
+    for p in model.parameters():
+        p.grad = torch.full_like(p, 10.0)
+    log_vars.grad = torch.full_like(log_vars, 10.0)
+    before = log_vars.grad.clone()
+
+    # ... then run the clip exactly as training_engine.py:1080 runs it.
+    torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+
+    assert grad_norm(model.parameters()) == pytest.approx(1.0, abs=1e-4), (
+        "the model gradient was not clipped — the premise of this test failed"
+    )
+    assert torch.equal(log_vars.grad, before), (
+        "log_vars.grad changed: the clip now covers the balancer. That is arguably the right "
+        "behaviour, but it changes training dynamics — update this characterisation on purpose."
+    )
+
+
+def test_every_parameter_receives_a_finite_non_zero_gradient():
+    """ALL parameters, not ``any``. A dead branch must be a test failure, not a silent null.
+
+    Runs the real ``_process_sequence`` on the real architecture and backpropagates the real
+    accumulated loss, then names every parameter that came back with no gradient, an all-zero
+    gradient, or a non-finite one.
+    """
+    x, model, h, idx, family = make_sequence(seed=7, T=5, hw=8)
+    out = _process_sequence(
+        x,
+        model,
+        h,
+        criterion_reg=FamilyLoss(family),
+        criterion_class=nn.BCEWithLogitsLoss(),
+        multitaskloss_instance=SumLoss(),
+        idx=idx,
+        device=torch.device("cpu"),
+        family=family,
+        ss_feedback="mean",
+        forecast_composition="soft_gate",
+    )
+    out["total"].backward()
+
+    missing, dead, nonfinite = [], [], []
+    for name, p in model.named_parameters():
+        if not p.requires_grad:
+            continue
+        if p.grad is None:
+            missing.append(name)
+        elif not torch.isfinite(p.grad).all():
+            nonfinite.append(name)
+        elif torch.count_nonzero(p.grad) == 0:
+            dead.append(name)
+
+    assert not missing, f"{len(missing)} parameters got NO gradient: {missing[:8]}"
+    assert not nonfinite, f"{len(nonfinite)} parameters got a non-finite gradient: {nonfinite[:8]}"
+    assert not dead, f"{len(dead)} parameters got an all-zero gradient: {dead[:8]}"
+
+
+def test_the_accumulated_gradient_is_finite_and_bounded():
+    """The whole-model gradient norm must be finite, and large enough to be real.
+
+    A separate assertion from the per-parameter one: a model can have every parameter wired and
+    still hand the optimizer an ``inf``. The ceiling is set two orders above the measured value
+    (~2.3 on this vehicle) so it catches an explosion, not ordinary drift.
+    """
+    x, model, h, idx, family = make_sequence(seed=7, T=5, hw=8)
+    out = _process_sequence(
+        x,
+        model,
+        h,
+        criterion_reg=FamilyLoss(family),
+        criterion_class=nn.BCEWithLogitsLoss(),
+        multitaskloss_instance=SumLoss(),
+        idx=idx,
+        device=torch.device("cpu"),
+        family=family,
+        ss_feedback="mean",
+        forecast_composition="soft_gate",
+    )
+    out["total"].backward()
+    n = grad_norm(model.parameters())
+    assert n > 0.0, "the accumulated gradient is exactly zero — nothing trained"
+    assert n == n and n != float("inf"), f"non-finite accumulated gradient norm: {n}"
+    assert n < 1e3, f"accumulated gradient norm {n:.4f} looks like an explosion, not training"

--- a/tests/train/test_gradient_health.py
+++ b/tests/train/test_gradient_health.py
@@ -32,7 +32,7 @@ from views_hydranet.train.training_engine import _process_sequence  # noqa: E402
 from .conftest import SumLoss, grad_norm, loop_config, loop_handler, make_sequence  # noqa: E402
 
 
-def _norms_at_step(clip: bool):
+def _norms_at_step(clip: bool, max_norm: float | None = None):
     """Run the real ``training_loop`` and record the gradient norm as the optimizer sees it.
 
     The spy wraps ``optimizer.step`` rather than ``clip_grad_norm_`` deliberately: patching the
@@ -41,6 +41,8 @@ def _norms_at_step(clip: bool):
     and fatal to the latter.
     """
     cfg = loop_config(clip_grad_norm=clip)
+    if max_norm is not None:
+        cfg["clip_grad_max_norm"] = max_norm
     device = torch.device("cpu")
     torch.manual_seed(cfg["torch_seed"])
     model, criterion, optimizer, scheduler = make(cfg, device)
@@ -199,3 +201,33 @@ def test_the_accumulated_gradient_is_finite_and_bounded():
     assert n > 0.0, "the accumulated gradient is exactly zero — nothing trained"
     assert n == n and n != float("inf"), f"non-finite accumulated gradient norm: {n}"
     assert n < 1e3, f"accumulated gradient norm {n:.4f} looks like an explosion, not training"
+
+
+def test_the_clip_threshold_is_configurable():
+    """C-314 regression: ``max_norm`` used to be a literal, so no config could tune it.
+
+    The bool field could only say on/off. ``clip_grad_max_norm`` defaults to 1.0 — which is why
+    the two tests above still read 1.0 and every pre-existing config is unchanged — but a config
+    that sets it must actually move the bound.
+
+    3.0 is chosen to sit strictly between the clipped 1.0 and the measured unclipped ~5.6, so a
+    threshold that is silently ignored fails in either direction.
+    """
+    norms = _norms_at_step(clip=True, max_norm=3.0)
+    assert norms, "optimizer.step was never called — the vehicle did not train"
+    for i, n in enumerate(norms):
+        assert n == pytest.approx(3.0, abs=1e-4), (
+            f"lesson {i}: asked for max_norm=3.0 and the optimizer saw {n:.4f}. The engine is "
+            "ignoring clip_grad_max_norm and using its old hardcoded threshold."
+        )
+
+
+def test_the_clip_default_is_unchanged_at_one():
+    """The C-112 half of C-314's fix: a config that never heard of the new field is untouched."""
+    from views_hydranet.utils.config_initializer import HydraNetConfig
+
+    field = HydraNetConfig.model_fields["clip_grad_max_norm"]
+    assert field.default == 1.0, (
+        f"clip_grad_max_norm now defaults to {field.default}, not 1.0 — every existing config "
+        "silently changes its clip threshold and results stop being comparable (C-112)."
+    )

--- a/tests/train/test_pushforward.py
+++ b/tests/train/test_pushforward.py
@@ -3,11 +3,13 @@
 Every test here exists because a plausible-looking implementation could pass without doing the
 thing. The specific traps, all real:
 
-* **The gradient cut is already free on our `sample` path.** `torch.poisson` severs it — measured as
+* **The gradient cut is already free on our `sample` path.** `torch.poisson` severs it —
+  measured as
   exactly 0.0 while the tensor stays graph-connected. An implementation consisting of a `.detach()`
   would be a NO-OP that looks correct, so the tests below check the SECOND UNROLL, which is the
   entire intervention here.
-* **The second step must consume the model's OWN field, not ground truth.** Feeding `t0` again would
+* **The second step must consume the model's OWN field, not ground truth.** Feeding `t0`
+  again would
   train an ordinary two-step teacher-forced model and still change the loss.
 * **The loss must be scored at t+2.** Scoring it at t+1 would duplicate the main term and still
   "work".
@@ -24,7 +26,7 @@ import torch.nn as nn  # noqa: E402
 from views_hydranet.architectures.registry import get_architecture  # noqa: E402
 from views_hydranet.distributions import get_family  # noqa: E402
 from views_hydranet.distributions.family_loss import FamilyLoss  # noqa: E402
-from views_hydranet.train.training_engine import _SequenceIndices, _process_sequence  # noqa: E402
+from views_hydranet.train.training_engine import _process_sequence, _SequenceIndices  # noqa: E402
 
 H = W = 8
 T = 6
@@ -42,17 +44,25 @@ class _MTL(nn.Module):
 def _fixture(seed=0):
     torch.manual_seed(seed)
     cfg = {
-        "features": FEATS, "regression_targets": FEATS, "classification_targets": CLS,
+        "features": FEATS,
+        "regression_targets": FEATS,
+        "classification_targets": CLS,
         "static_channels": [],
     }
     names = FEATS + CLS
     idx = _SequenceIndices(names, cfg)
-    model = get_architecture("HydraBNUNet06_LSTM4")(
-        len(FEATS), 32, 1, 0.0, output_distribution="nb"
-    ).float().train()
+    model = (
+        get_architecture("HydraBNUNet06_LSTM4")(len(FEATS), 32, 1, 0.0, output_distribution="nb")
+        .float()
+        .train()
+    )
     h = model.init_hTtime(model.base, H, W).float()
     # log1p-space counts, mostly zero like the real grid
-    x = (torch.rand(1, T, len(names), H, W) < 0.05).float() * torch.rand(1, T, len(names), H, W) * 3
+    x = (
+        (torch.rand(1, T, len(names), H, W) < 0.05).float()
+        * torch.rand(1, T, len(names), H, W)
+        * 3
+    )
     return x, model, h, idx, get_family("nb")
 
 
@@ -61,11 +71,20 @@ def _run(pf_weight=0.0, detach_state=False, seed=0, tensor=None, **kw):
     if tensor is not None:
         x = tensor
     out = _process_sequence(
-        x, model, h,
-        criterion_reg=FamilyLoss(fam), criterion_class=nn.BCEWithLogitsLoss(),
-        multitaskloss_instance=_MTL(), idx=idx, device=torch.device("cpu"),
-        family=fam, ss_feedback="sample", forecast_composition="soft_gate",
-        pushforward_weight=pf_weight, pushforward_detach_state=detach_state, **kw,
+        x,
+        model,
+        h,
+        criterion_reg=FamilyLoss(fam),
+        criterion_class=nn.BCEWithLogitsLoss(),
+        multitaskloss_instance=_MTL(),
+        idx=idx,
+        device=torch.device("cpu"),
+        family=fam,
+        ss_feedback="sample",
+        forecast_composition="soft_gate",
+        pushforward_weight=pf_weight,
+        pushforward_detach_state=detach_state,
+        **kw,
     )
     return out, model, x
 
@@ -140,7 +159,8 @@ def test_the_second_step_consumes_the_models_own_field_not_ground_truth():
     """Recompute the pushforward term independently and require an exact match.
 
     The previous version of this test grepped the source for `_family_feedback_log1p(`. A mutation
-    that left that line in place and fed `t0_input` to the model instead **passed all seven tests** —
+    that left that line in place and fed `t0_input` to the model instead **passed all seven
+    tests** —
     the string was present, the property was gone. That is the same grep-the-source failure the
     project keeps registering, so this recomputes the term from first principles instead.
 
@@ -159,9 +179,17 @@ def test_the_second_step_consumes_the_models_own_field_not_ground_truth():
     def run(w):
         m, hh = _fixture(seed=21)[1], _fixture(seed=21)[2]
         return _process_sequence(
-            short, m, hh, criterion_reg=crit, criterion_class=nn.BCEWithLogitsLoss(),
-            multitaskloss_instance=_MTL(), idx=idx, device=torch.device("cpu"),
-            family=fam, ss_feedback="mean", forecast_composition="soft_gate",
+            short,
+            m,
+            hh,
+            criterion_reg=crit,
+            criterion_class=nn.BCEWithLogitsLoss(),
+            multitaskloss_instance=_MTL(),
+            idx=idx,
+            device=torch.device("cpu"),
+            family=fam,
+            ss_feedback="mean",
+            forecast_composition="soft_gate",
             pushforward_weight=w,
         )["total"]
 
@@ -218,7 +246,7 @@ def test_gradient_into_the_fed_field_is_cut():
 
 
 def test_detach_state_changes_the_gradient_but_not_the_loss():
-    """The recurrent fork: detaching `h` must alter gradients while leaving the forward value alone.
+    """The recurrent fork: detaching `h` must alter gradients but not the forward value.
 
     If the two settings produced identical gradients the flag would be decorative; if they produced
     different losses it would be doing something other than cutting a gradient path.

--- a/tests/train/test_pushforward.py
+++ b/tests/train/test_pushforward.py
@@ -160,20 +160,27 @@ def test_the_second_step_consumes_the_models_own_field_not_ground_truth():
 
     The previous version of this test grepped the source for `_family_feedback_log1p(`. A mutation
     that left that line in place and fed `t0_input` to the model instead **passed all seven
-    tests** —
-    the string was present, the property was gone. That is the same grep-the-source failure the
-    project keeps registering, so this recomputes the term from first principles instead.
+    tests** — the string was present, the property was gone. That is the same grep-the-source
+    failure the project keeps registering, so this recomputes the term from first principles.
 
     Uses `ss_feedback='mean'`, which is analytic and needs no RNG, so the reference is exact. The
     plumbing under test — WHICH tensor reaches the second forward — is identical on both paths.
+
+    The field here is deliberately DENSER and larger than the real grid. This test is about
+    plumbing, not about a realistic regime, and on a near-empty field every candidate input
+    produces nearly the same loss, leaving too little margin to tell a correct implementation from
+    a wrong one. Measured on this fixture: feeding the model's own field differs from feeding `t0`
+    by 2.8e-2 and from feeding ground truth at t+1 by 1.3e-2, both ~100x the 1e-4 match tolerance.
     """
     from views_hydranet.train.training_engine import (
         _attach_static_channels,
+        _batchnorm_eval,
         _family_feedback_log1p,
     )
 
     x, model, h, idx, fam = _fixture(seed=21)
-    short = x[:, :3].clone()
+    torch.manual_seed(21)
+    short = (torch.rand(1, 3, 6, H, W) < 0.25).float() * torch.rand(1, 3, 6, H, W) * 8
     crit = FamilyLoss(fam)
 
     def run(w):
@@ -205,7 +212,10 @@ def test_the_second_step_consumes_the_models_own_field_not_ground_truth():
     ).detach()
 
     def pf_from(inp, state):
-        o = m(inp, state)
+        # mirrors the engine: the extra forward runs with BN frozen so it cannot write running
+        # statistics (see the C-184 note in _process_sequence)
+        with _batchnorm_eval(m):
+            o = m(inp, state)
         y2 = short[:, 2, idx.reg]
         n = crit.n_params
         return sum(
@@ -213,18 +223,23 @@ def test_the_second_step_consumes_the_models_own_field_not_ground_truth():
             for j in range(len(idx.reg_names))
         ).item()
 
-    from_own_field = pf_from(_attach_static_channels(fed, t0, idx), out0.h_next)
-    from_ground_truth = pf_from(t0_input, out0.h_next)
+    t1 = short[:, 1]
+    from_own_field = pf_from(_attach_static_channels(fed, t1, idx), out0.h_next)
+    # the two implementations this must rule out
+    fed_t0_again = pf_from(t0_input, out0.h_next)
+    fed_truth_at_t1 = pf_from(_attach_static_channels(t1[:, idx.feat], t1, idx), out0.h_next)
 
     assert observed == pytest.approx(from_own_field, rel=1e-4), (
         f"the pushforward term ({observed:.6f}) does not match a second step fed the model's own "
         f"field ({from_own_field:.6f})"
     )
-    # and the two must be far enough apart that the check above could ever fail
-    assert abs(from_own_field - from_ground_truth) / abs(from_own_field) > 1e-2, (
-        "feeding ground truth and feeding the model's own field give nearly the same loss here, "
-        "so this fixture cannot discriminate — the test would be vacuous"
-    )
+    for label, wrong in (("t0 again", fed_t0_again), ("ground truth at t+1", fed_truth_at_t1)):
+        margin = abs(from_own_field - wrong) / abs(from_own_field)
+        assert margin > 1e-2, (
+            f"feeding {label} gives nearly the same loss as the model's own field "
+            f"(relative gap {margin:.2e}), so the assertion above could not tell them apart — "
+            "the test would be vacuous on this fixture"
+        )
 
 
 def test_gradient_into_the_fed_field_is_cut():
@@ -270,3 +285,94 @@ def test_the_last_step_is_skipped_rather_than_indexing_past_the_end():
     """`i + 2 < seq_len` must hold; an off-by-one here would crash mid-training, hours in."""
     out, _, _ = _run(pf_weight=1.0, seed=13)
     assert torch.isfinite(out["total"]).all()
+
+
+def _bn_state(model):
+    """Snapshot every BatchNorm running buffer, so a test can prove none of them moved."""
+    out = {}
+    for name, m in model.named_modules():
+        if isinstance(m, torch.nn.modules.batchnorm._BatchNorm):
+            out[name] = (
+                m.running_mean.clone(),
+                m.running_var.clone(),
+                m.num_batches_tracked.clone(),
+            )
+    return out
+
+
+def test_the_extra_forward_does_not_touch_batchnorm_running_statistics():
+    """The pushforward must not write model STATE — only a loss term.
+
+    Found by review, and it was real: the extra ``model(...)`` call runs while the model is in
+    ``train()`` mode, so it updated ``running_mean``/``running_var``/``num_batches_tracked`` on all
+    15 BN layers. Measured before the fix on a T=6 window: ``num_batches_tracked`` 5 -> 9, and
+    ``bn_enc_conv0.running_mean`` moved by 0.054. Roughly half the saved BN statistics would have
+    come from self-fed, off-distribution inputs.
+
+    That is not a cosmetic leak. BN buffers go into the artifact and are used at eval, and the
+    C-184 recalibration (``bn_recalibrate: True`` by default) recomputes them with
+    ``momentum=None`` — a cumulative average, so the pushforward forwards would carry EQUAL weight.
+    An arm with ``pushforward_weight > 0`` would then differ from its ``0.0`` control at the BN
+    layer for reasons having nothing to do with the auxiliary loss: the A/B confounded, silently.
+
+    ``torch.no_grad()`` is not a defence — it stops gradients, not buffer updates.
+    """
+    counts = {}
+    for weight in (0.0, 0.5):
+        x, model, h, idx, fam = _fixture(seed=11)
+        before = _bn_state(model)
+        _process_sequence(
+            x,
+            model,
+            h,
+            criterion_reg=FamilyLoss(fam),
+            criterion_class=nn.BCEWithLogitsLoss(),
+            multitaskloss_instance=_MTL(),
+            idx=idx,
+            device=torch.device("cpu"),
+            family=fam,
+            ss_feedback="mean",
+            forecast_composition="soft_gate",
+            pushforward_weight=weight,
+        )
+        after = _bn_state(model)
+        assert before, "the fixture model has no BatchNorm layers — this test cannot bite"
+        counts[weight] = {k: int(v[2]) for k, v in after.items()}
+
+    assert counts[0.0] == counts[0.5], (
+        "the pushforward changed how many batches BatchNorm has seen "
+        f"({counts[0.0]} vs {counts[0.5]}). Its extra forward is updating BN running statistics, "
+        "which are model state saved into the artifact and recomputed by the C-184 recalibration "
+        "— an arm would differ from its control at the BN layer for reasons unrelated to the loss."
+    )
+
+
+def test_the_pushforward_is_skipped_when_gradients_are_off():
+    """Under ``no_grad`` the term is computed and thrown away — that is pure cost.
+
+    ``_recalibrate_bn`` drives the same ``train()`` code path under ``no_grad`` to recompute BN
+    statistics. Nothing there can consume a loss, so the extra forward buys nothing and costs a
+    full second pass per step.
+    """
+    x, model, h, idx, fam = _fixture(seed=13)
+    kwargs = dict(
+        criterion_reg=FamilyLoss(fam),
+        criterion_class=nn.BCEWithLogitsLoss(),
+        multitaskloss_instance=_MTL(),
+        idx=idx,
+        device=torch.device("cpu"),
+        family=fam,
+        ss_feedback="mean",
+        forecast_composition="soft_gate",
+    )
+    with torch.no_grad():
+        off = _process_sequence(x, model, h, pushforward_weight=0.0, **kwargs)["total"]
+    x2, model2, h2, _, _ = _fixture(seed=13)
+    with torch.no_grad():
+        on = _process_sequence(x2, model2, h2, pushforward_weight=1.0, **kwargs)["total"]
+
+    assert torch.equal(off, on), (
+        f"under no_grad, pushforward_weight=1.0 changed the loss ({on.item()} vs {off.item()}). "
+        "The term is still being computed on a path that cannot use it — pure cost during BN "
+        "recalibration."
+    )

--- a/tests/train/test_pushforward.py
+++ b/tests/train/test_pushforward.py
@@ -417,51 +417,70 @@ def _fixture_with_statics(seed=0, T=4):
 def test_the_fed_field_gets_its_statics_from_t_plus_one_not_t():
     """The fed field stands in for t+1, so its statics must come from t1.
 
-    Inert today (production runs ``static_channels: []``, making the helper a no-op) and a real bug
-    the moment a channel that varies in time is declared static. Observable only with a static
-    channel present, which is why this test builds one.
+    Recomputed, not compared-against-a-perturbation: shifting the static values changes the loss
+    under EITHER reading, so a "did it move?" test cannot tell t0 from t1. This builds the
+    reference twice — once with t1's statics, once with t0's — and requires the engine to match
+    the first and differ from the second.
+
+    Inert today (production runs ``static_channels: []``, making the helper a no-op) and a real
+    bug the moment a channel that varies in time is declared static.
     """
-    x, model, h, idx, fam = _fixture_with_statics(seed=17)
+    from views_hydranet.train.training_engine import (
+        _attach_static_channels,
+        _batchnorm_eval,
+        _family_feedback_log1p,
+    )
+
+    x, _model, _h, idx, fam = _fixture_with_statics(seed=17, T=3)
     assert idx.static, "the fixture declares no static channel — this test cannot bite"
+    crit = FamilyLoss(fam)
 
-    out = _process_sequence(
-        x,
-        model,
-        h,
-        criterion_reg=FamilyLoss(fam),
-        criterion_class=nn.BCEWithLogitsLoss(),
-        multitaskloss_instance=_MTL(),
-        idx=idx,
-        device=torch.device("cpu"),
-        family=fam,
-        ss_feedback="mean",
-        forecast_composition="soft_gate",
-        pushforward_weight=1.0,
-    )
+    def run(w):
+        _, m, hh, _, _ = _fixture_with_statics(seed=17, T=3)
+        return _process_sequence(
+            x,
+            m,
+            hh,
+            criterion_reg=crit,
+            criterion_class=nn.BCEWithLogitsLoss(),
+            multitaskloss_instance=_MTL(),
+            idx=idx,
+            device=torch.device("cpu"),
+            family=fam,
+            ss_feedback="mean",
+            forecast_composition="soft_gate",
+            pushforward_weight=w,
+        )["total"]
 
-    # Rebuild the same run with the per-frame static constants shifted by one, so a t0-indexed
-    # read produces the value a t1-indexed read produced before. If the engine reads t0, the
-    # pushforward term is unchanged by the shift; if it reads t1, it moves.
-    x2, model2, h2, idx2, fam2 = _fixture_with_statics(seed=17)
-    for t in range(x2.shape[1]):
-        x2[:, t, idx2.static] = float(t + 2)
-    out2 = _process_sequence(
-        x2,
-        model2,
-        h2,
-        criterion_reg=FamilyLoss(fam2),
-        criterion_class=nn.BCEWithLogitsLoss(),
-        multitaskloss_instance=_MTL(),
-        idx=idx2,
-        device=torch.device("cpu"),
-        family=fam2,
-        ss_feedback="mean",
-        forecast_composition="soft_gate",
-        pushforward_weight=1.0,
+    observed = (run(1.0) - run(0.0)).item()
+
+    # --- reference: step 0 only, since `i + 2 < 3` fires exactly once ---
+    _, m, hh, _, _ = _fixture_with_statics(seed=17, T=3)
+    t0, t1 = x[:, 0], x[:, 1]
+    out0 = m(_attach_static_channels(t0[:, idx.feat], t0, idx), hh)
+    fed = _family_feedback_log1p(
+        out0.reg, fam, "mean", torch.sigmoid(out0.cls), "soft_gate", None
+    ).detach()
+
+    def pf_with(static_source):
+        with _batchnorm_eval(m):
+            o = m(_attach_static_channels(fed, static_source, idx), out0.h_next)
+        y2 = x[:, 2, idx.reg]
+        n = crit.n_params
+        return sum(
+            crit(o.reg[:, j * n : (j + 1) * n].permute(0, 2, 3, 1), y2[:, j])
+            for j in range(len(idx.reg_names))
+        ).item()
+
+    from_t1, from_t0 = pf_with(t1), pf_with(t0)
+    margin = abs(from_t1 - from_t0) / abs(from_t1)
+    assert margin > 1e-3, (
+        f"t0 and t1 statics give nearly the same pushforward loss (gap {margin:.2e}) — this "
+        "fixture cannot tell them apart, so the assertion below would be vacuous"
     )
-    assert not torch.equal(out["total"], out2["total"]), (
-        "shifting the static channel by one frame left the loss identical — the statics are not "
-        "being read per-frame at all, so this test cannot detect which frame the pushforward used"
+    assert observed == pytest.approx(from_t1, rel=1e-4), (
+        f"the pushforward term ({observed:.6f}) matches neither a t1-static reference "
+        f"({from_t1:.6f}); the t0-static value is {from_t0:.6f}"
     )
 
 

--- a/tests/train/test_pushforward.py
+++ b/tests/train/test_pushforward.py
@@ -379,7 +379,7 @@ def test_the_pushforward_is_skipped_when_gradients_are_off():
 
 
 def _fixture_with_statics(seed=0, T=4):
-    """Like ``_fixture`` but with one static channel, so tests can tell WHICH frame it was read from.
+    """Like ``_fixture`` but with one static channel, so a test can tell WHICH frame it used.
 
     The static channel is given a different constant per frame — physically wrong (statics are
     geometry-constant by definition) and deliberately so: it is the only way to observe which time

--- a/tests/train/test_pushforward.py
+++ b/tests/train/test_pushforward.py
@@ -376,3 +376,131 @@ def test_the_pushforward_is_skipped_when_gradients_are_off():
         "The term is still being computed on a path that cannot use it — pure cost during BN "
         "recalibration."
     )
+
+
+def _fixture_with_statics(seed=0, T=4):
+    """Like ``_fixture`` but with one static channel, so tests can tell WHICH frame it was read from.
+
+    The static channel is given a different constant per frame — physically wrong (statics are
+    geometry-constant by definition) and deliberately so: it is the only way to observe which time
+    index ``_attach_static_channels`` was handed. With the production ``static_channels: []`` the
+    helper is a no-op and the question is unobservable.
+    """
+    torch.manual_seed(seed)
+    static = ["coord_row"]
+    cfg = {
+        "features": FEATS,
+        "regression_targets": FEATS,
+        "classification_targets": CLS,
+        "static_channels": static,
+    }
+    names = FEATS + CLS + static
+    idx = _SequenceIndices(names, cfg)
+    model = (
+        get_architecture("HydraBNUNet06_LSTM4")(
+            len(FEATS) + len(static), 32, 1, 0.0, output_distribution="nb"
+        )
+        .float()
+        .train()
+    )
+    h = model.init_hTtime(model.base, H, W).float()
+    x = (
+        (torch.rand(1, T, len(names), H, W) < 0.25).float()
+        * torch.rand(1, T, len(names), H, W)
+        * 8
+    )
+    for t in range(T):  # a distinct constant per frame
+        x[:, t, idx.static] = float(t + 1)
+    return x, model, h, idx, get_family("nb")
+
+
+def test_the_fed_field_gets_its_statics_from_t_plus_one_not_t():
+    """The fed field stands in for t+1, so its statics must come from t1.
+
+    Inert today (production runs ``static_channels: []``, making the helper a no-op) and a real bug
+    the moment a channel that varies in time is declared static. Observable only with a static
+    channel present, which is why this test builds one.
+    """
+    x, model, h, idx, fam = _fixture_with_statics(seed=17)
+    assert idx.static, "the fixture declares no static channel — this test cannot bite"
+
+    out = _process_sequence(
+        x,
+        model,
+        h,
+        criterion_reg=FamilyLoss(fam),
+        criterion_class=nn.BCEWithLogitsLoss(),
+        multitaskloss_instance=_MTL(),
+        idx=idx,
+        device=torch.device("cpu"),
+        family=fam,
+        ss_feedback="mean",
+        forecast_composition="soft_gate",
+        pushforward_weight=1.0,
+    )
+
+    # Rebuild the same run with the per-frame static constants shifted by one, so a t0-indexed
+    # read produces the value a t1-indexed read produced before. If the engine reads t0, the
+    # pushforward term is unchanged by the shift; if it reads t1, it moves.
+    x2, model2, h2, idx2, fam2 = _fixture_with_statics(seed=17)
+    for t in range(x2.shape[1]):
+        x2[:, t, idx2.static] = float(t + 2)
+    out2 = _process_sequence(
+        x2,
+        model2,
+        h2,
+        criterion_reg=FamilyLoss(fam2),
+        criterion_class=nn.BCEWithLogitsLoss(),
+        multitaskloss_instance=_MTL(),
+        idx=idx2,
+        device=torch.device("cpu"),
+        family=fam2,
+        ss_feedback="mean",
+        forecast_composition="soft_gate",
+        pushforward_weight=1.0,
+    )
+    assert not torch.equal(out["total"], out2["total"]), (
+        "shifting the static channel by one frame left the loss identical — the statics are not "
+        "being read per-frame at all, so this test cannot detect which frame the pushforward used"
+    )
+
+
+def test_the_pushforward_term_honours_target_weights():
+    """C-87 parity: the auxiliary term must use the same per-target weights as the primary loss.
+
+    Without this the pushforward silently re-weights the targets relative to the main objective —
+    inert while ``target_weights`` is None (the production default), wrong as soon as it is set.
+    """
+    kwargs = dict(
+        criterion_class=nn.BCEWithLogitsLoss(),
+        multitaskloss_instance=_MTL(),
+        device=torch.device("cpu"),
+        ss_feedback="mean",
+        forecast_composition="soft_gate",
+    )
+
+    def run(weights, pf):
+        x, model, h, idx, fam = _fixture(seed=23)
+        return _process_sequence(
+            x,
+            model,
+            h,
+            criterion_reg=FamilyLoss(fam),
+            idx=idx,
+            family=fam,
+            target_weights=weights,
+            pushforward_weight=pf,
+            **kwargs,
+        )["total"].item()
+
+    flat = {name: 1.0 for name in FEATS}
+    tilted = dict(flat, **{FEATS[0]: 5.0})
+
+    # the weight change must move the pushforward CONTRIBUTION, not just the primary loss
+    pf_contrib_flat = run(flat, 1.0) - run(flat, 0.0)
+    pf_contrib_tilted = run(tilted, 1.0) - run(tilted, 0.0)
+    assert abs(pf_contrib_tilted - pf_contrib_flat) > 1e-6 * abs(pf_contrib_flat), (
+        f"target_weights changed the primary loss but not the pushforward term "
+        f"({pf_contrib_flat:.6f} vs {pf_contrib_tilted:.6f}) — the auxiliary objective is "
+        "weighting the targets differently from the primary one (C-87)."
+    )

--- a/tests/train/test_pushforward.py
+++ b/tests/train/test_pushforward.py
@@ -137,19 +137,66 @@ def test_the_loss_is_scored_at_t_plus_2_not_t_plus_1():
 
 
 def test_the_second_step_consumes_the_models_own_field_not_ground_truth():
-    """The extra step must be fed the model's emitted field.
+    """Recompute the pushforward term independently and require an exact match.
 
-    Feeding `t0` again would train a two-step teacher-forced model: the loss would still change and
-    still scale, so only inspecting the call can distinguish them. The source is read directly.
+    The previous version of this test grepped the source for `_family_feedback_log1p(`. A mutation
+    that left that line in place and fed `t0_input` to the model instead **passed all seven tests** —
+    the string was present, the property was gone. That is the same grep-the-source failure the
+    project keeps registering, so this recomputes the term from first principles instead.
+
+    Uses `ss_feedback='mean'`, which is analytic and needs no RNG, so the reference is exact. The
+    plumbing under test — WHICH tensor reaches the second forward — is identical on both paths.
     """
-    import inspect
+    from views_hydranet.train.training_engine import (
+        _attach_static_channels,
+        _family_feedback_log1p,
+    )
 
-    src = inspect.getsource(_process_sequence)
-    pf = src[src.index("PUSHFORWARD (Brandstetter"):]
-    pf = pf[: pf.index("losses = torch.stack")]
-    assert "_family_feedback_log1p(" in pf, "the extra step is not fed the model's emitted field"
-    assert ".detach()" in pf, "the fed field is not detached — the gradient is not cut"
-    assert "i + 2" in pf, "the target is not t+2"
+    x, model, h, idx, fam = _fixture(seed=21)
+    short = x[:, :3].clone()
+    crit = FamilyLoss(fam)
+
+    def run(w):
+        m, hh = _fixture(seed=21)[1], _fixture(seed=21)[2]
+        return _process_sequence(
+            short, m, hh, criterion_reg=crit, criterion_class=nn.BCEWithLogitsLoss(),
+            multitaskloss_instance=_MTL(), idx=idx, device=torch.device("cpu"),
+            family=fam, ss_feedback="mean", forecast_composition="soft_gate",
+            pushforward_weight=w,
+        )["total"]
+
+    observed = (run(1.0) - run(0.0)).item()
+
+    # --- independent reference: step 0 only, since `i + 2 < 3` fires just once ---
+    m, hh = _fixture(seed=21)[1], _fixture(seed=21)[2]
+    t0 = short[:, 0]
+    t0_input = _attach_static_channels(t0[:, idx.feat], t0, idx)
+    out0 = m(t0_input, hh)
+    fed = _family_feedback_log1p(
+        out0.reg, fam, "mean", torch.sigmoid(out0.cls), "soft_gate", None
+    ).detach()
+
+    def pf_from(inp, state):
+        o = m(inp, state)
+        y2 = short[:, 2, idx.reg]
+        n = crit.n_params
+        return sum(
+            crit(o.reg[:, j * n : (j + 1) * n].permute(0, 2, 3, 1), y2[:, j])
+            for j in range(len(idx.reg_names))
+        ).item()
+
+    from_own_field = pf_from(_attach_static_channels(fed, t0, idx), out0.h_next)
+    from_ground_truth = pf_from(t0_input, out0.h_next)
+
+    assert observed == pytest.approx(from_own_field, rel=1e-4), (
+        f"the pushforward term ({observed:.6f}) does not match a second step fed the model's own "
+        f"field ({from_own_field:.6f})"
+    )
+    # and the two must be far enough apart that the check above could ever fail
+    assert abs(from_own_field - from_ground_truth) / abs(from_own_field) > 1e-2, (
+        "feeding ground truth and feeding the model's own field give nearly the same loss here, "
+        "so this fixture cannot discriminate — the test would be vacuous"
+    )
 
 
 def test_gradient_into_the_fed_field_is_cut():

--- a/tests/train/test_pushforward.py
+++ b/tests/train/test_pushforward.py
@@ -1,0 +1,197 @@
+"""Pushforward (#289, Brandstetter et al. 2022) — prove the mechanism, not the shape.
+
+Every test here exists because a plausible-looking implementation could pass without doing the
+thing. The specific traps, all real:
+
+* **The gradient cut is already free on our `sample` path.** `torch.poisson` severs it — measured as
+  exactly 0.0 while the tensor stays graph-connected. An implementation consisting of a `.detach()`
+  would be a NO-OP that looks correct, so the tests below check the SECOND UNROLL, which is the
+  entire intervention here.
+* **The second step must consume the model's OWN field, not ground truth.** Feeding `t0` again would
+  train an ordinary two-step teacher-forced model and still change the loss.
+* **The loss must be scored at t+2.** Scoring it at t+1 would duplicate the main term and still
+  "work".
+* **Default-off must be byte-identical**, or every existing result is on a different objective.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+import torch.nn as nn  # noqa: E402
+
+from views_hydranet.architectures.registry import get_architecture  # noqa: E402
+from views_hydranet.distributions import get_family  # noqa: E402
+from views_hydranet.distributions.family_loss import FamilyLoss  # noqa: E402
+from views_hydranet.train.training_engine import _SequenceIndices, _process_sequence  # noqa: E402
+
+H = W = 8
+T = 6
+FEATS = ["lr_sb_best", "lr_ns_best", "lr_os_best"]
+CLS = ["by_sb_best", "by_ns_best", "by_os_best"]
+
+
+class _MTL(nn.Module):
+    """Stand-in for the multitask loss: a plain sum, so the test reads the real terms."""
+
+    def forward(self, losses):
+        return losses.sum()
+
+
+def _fixture(seed=0):
+    torch.manual_seed(seed)
+    cfg = {
+        "features": FEATS, "regression_targets": FEATS, "classification_targets": CLS,
+        "static_channels": [],
+    }
+    names = FEATS + CLS
+    idx = _SequenceIndices(names, cfg)
+    model = get_architecture("HydraBNUNet06_LSTM4")(
+        len(FEATS), 32, 1, 0.0, output_distribution="nb"
+    ).float().train()
+    h = model.init_hTtime(model.base, H, W).float()
+    # log1p-space counts, mostly zero like the real grid
+    x = (torch.rand(1, T, len(names), H, W) < 0.05).float() * torch.rand(1, T, len(names), H, W) * 3
+    return x, model, h, idx, get_family("nb")
+
+
+def _run(pf_weight=0.0, detach_state=False, seed=0, tensor=None, **kw):
+    x, model, h, idx, fam = _fixture(seed)
+    if tensor is not None:
+        x = tensor
+    out = _process_sequence(
+        x, model, h,
+        criterion_reg=FamilyLoss(fam), criterion_class=nn.BCEWithLogitsLoss(),
+        multitaskloss_instance=_MTL(), idx=idx, device=torch.device("cpu"),
+        family=fam, ss_feedback="sample", forecast_composition="soft_gate",
+        pushforward_weight=pf_weight, pushforward_detach_state=detach_state, **kw,
+    )
+    return out, model, x
+
+
+def test_default_off_is_byte_identical():
+    """weight=0 must not merely be 'close' — the term must never be computed."""
+    a, _, _ = _run(pf_weight=0.0, seed=3)
+    b, _, _ = _run(pf_weight=0.0, seed=3)
+    assert torch.equal(a["total"], b["total"]), "the run is not deterministic"
+
+    # and a weighted run must actually DIFFER, or the flag does nothing
+    c, _, _ = _run(pf_weight=1.0, seed=3)
+    assert not torch.equal(a["total"], c["total"]), (
+        "pushforward_weight=1.0 produced the same loss as 0.0 — the term is inert"
+    )
+
+
+def test_the_term_scales_with_its_weight():
+    """A weight that does not move the loss monotonically is not being applied as a weight."""
+    base, _, _ = _run(pf_weight=0.0, seed=5)
+    one, _, _ = _run(pf_weight=1.0, seed=5)
+    two, _, _ = _run(pf_weight=2.0, seed=5)
+    d1 = (one["total"] - base["total"]).item()
+    d2 = (two["total"] - base["total"]).item()
+    assert d1 > 0, "the pushforward term is not positive"
+    assert d2 == pytest.approx(2 * d1, rel=1e-4), (
+        f"the term does not scale linearly with the weight: {d1} then {d2}"
+    )
+
+
+def test_the_loss_is_scored_at_t_plus_2_not_t_plus_1():
+    """THE discriminating test — and the first version of it did NOT discriminate.
+
+    Perturbing a middle frame cannot separate the two: every frame is a t+1 target for one step and
+    a t+2 target for another, so the term responds either way. A mutation scoring at t+1 passed.
+
+    With a 3-frame sequence there are two steps, and pushforward fires only at step 0 (it needs
+    `i + 2 < seq_len`), scoring frame 2. **Frame 1 is then a t+1 target and never a t+2 target.**
+    So perturbing frame 1 alone must leave the pushforward term EXACTLY unchanged — while an
+    implementation scoring at t+1 would move.
+    """
+    x, model, h, idx, fam = _fixture(seed=7)
+    short = x[:, :3].clone()
+
+    def pf_term(tensor):
+        with_pf, _, _ = _run(pf_weight=1.0, seed=7, tensor=tensor)
+        without, _, _ = _run(pf_weight=0.0, seed=7, tensor=tensor)
+        return (with_pf["total"] - without["total"]).item()
+
+    # The term is isolated by subtracting two large losses, so float32 cancellation sets the
+    # floor: an unchanged term still wobbles ~1e-6 on values ~2. The discriminator is therefore
+    # "wobbles" vs "moves substantially", not exact equality.
+    base = pf_term(short)
+
+    only_t1 = short.clone()
+    only_t1[:, 1, :3] += 3.0  # frame 1: a t+1 target, NEVER a t+2 target
+    drift = abs(pf_term(only_t1) - base) / abs(base)
+    assert drift < 1e-4, (
+        f"the pushforward term moved {drift:.2e} (relative) when only a t+1 target changed — "
+        "it is scored at t+1, not t+2"
+    )
+
+    only_t2 = short.clone()
+    only_t2[:, 2, :3] += 3.0  # frame 2: the t+2 target for step 0
+    moved = abs(pf_term(only_t2) - base) / abs(base)
+    assert moved > 1e-2, (
+        f"the pushforward term moved only {moved:.2e} (relative) when its own t+2 target changed"
+    )
+
+
+def test_the_second_step_consumes_the_models_own_field_not_ground_truth():
+    """The extra step must be fed the model's emitted field.
+
+    Feeding `t0` again would train a two-step teacher-forced model: the loss would still change and
+    still scale, so only inspecting the call can distinguish them. The source is read directly.
+    """
+    import inspect
+
+    src = inspect.getsource(_process_sequence)
+    pf = src[src.index("PUSHFORWARD (Brandstetter"):]
+    pf = pf[: pf.index("losses = torch.stack")]
+    assert "_family_feedback_log1p(" in pf, "the extra step is not fed the model's emitted field"
+    assert ".detach()" in pf, "the fed field is not detached — the gradient is not cut"
+    assert "i + 2" in pf, "the target is not t+2"
+
+
+def test_gradient_into_the_fed_field_is_cut():
+    """The fed field must carry no gradient — measured, not asserted from the source.
+
+    On the `sample` path this is already true before any `.detach()` (torch.poisson severs it), so
+    this pins the property rather than the line of code that is supposed to produce it.
+    """
+    from views_hydranet.train.training_engine import _family_feedback_log1p
+
+    fam = get_family("nb")
+    reg = (torch.rand(1, 6, H, W) + 0.5).requires_grad_(True)
+    gate = torch.rand(1, 3, H, W)
+    fed = _family_feedback_log1p(reg, fam, "sample", gate, "soft_gate", None)
+    fed.sum().backward()
+    assert reg.grad is None or float(reg.grad.abs().sum()) == 0.0, (
+        "gradient reaches the params through the sampled feedback — the cut is not in effect"
+    )
+
+
+def test_detach_state_changes_the_gradient_but_not_the_loss():
+    """The recurrent fork: detaching `h` must alter gradients while leaving the forward value alone.
+
+    If the two settings produced identical gradients the flag would be decorative; if they produced
+    different losses it would be doing something other than cutting a gradient path.
+    """
+    lo, model_a, _ = _run(pf_weight=1.0, detach_state=False, seed=11)
+    hi, model_b, _ = _run(pf_weight=1.0, detach_state=True, seed=11)
+    assert lo["total"].item() == pytest.approx(hi["total"].item(), rel=1e-6), (
+        "detaching the state changed the forward loss; it must only change gradient flow"
+    )
+
+    lo["total"].backward()
+    hi["total"].backward()
+    ga = torch.cat([p.grad.flatten() for p in model_a.parameters() if p.grad is not None])
+    gb = torch.cat([p.grad.flatten() for p in model_b.parameters() if p.grad is not None])
+    assert not torch.allclose(ga, gb, atol=1e-8), (
+        "detaching the recurrent state left gradients unchanged — the flag is decorative"
+    )
+
+
+def test_the_last_step_is_skipped_rather_than_indexing_past_the_end():
+    """`i + 2 < seq_len` must hold; an off-by-one here would crash mid-training, hours in."""
+    out, _, _ = _run(pf_weight=1.0, seed=13)
+    assert torch.isfinite(out["total"]).all()

--- a/views_hydranet/architectures/HydraBNrecurrentUnet_06_LSTM4.py
+++ b/views_hydranet/architectures/HydraBNrecurrentUnet_06_LSTM4.py
@@ -102,8 +102,16 @@ class HydraBNUNet06_LSTM4(nn.Module):
         # reg_activation overrides it (Exp B: decouple emit activation from the loss/likelihood).
         # C-178: a ReLU output head dies on rare targets under the hurdle mask (pre-activation
         # drifts 100% negative => ReLU==0 with zero gradient => unrecoverable). softplus is always
-        # positive with non-zero gradient, so it cannot die. hurdle_nb already used softplus;
+        # positive with non-zero gradient, so IT cannot die. hurdle_nb already used softplus;
         # extend to all hurdle bodies. "standard" keeps relu (byte-identical to pre-#100).
+        #
+        # C-313: that last clause is about the ACTIVATION, not the path. For the family heads,
+        # `nb_core._clamp` applies `clamp_min(1e-6)` downstream, and `clamp_min` passes exactly
+        # zero gradient below its floor — so the path CAN die, at raw <= log(expm1(1e-6)) ~ -13.82.
+        # Latent on the current vehicle (the trained incumbent's min raw_mu is -3.81, and the
+        # gradient there points away from the edge), pinned by
+        # tests/distributions/test_gradient_dead_zones.py. Do not read this comment as a guarantee
+        # that the emitted mu/theta cannot reach a zero-gradient state.
         if self._family is not None:
             self._reg_activation = _family_activation(self._family)
         elif reg_activation == "softplus":

--- a/views_hydranet/train/training_engine.py
+++ b/views_hydranet/train/training_engine.py
@@ -976,6 +976,7 @@ def training_loop(
             lesson_loss = torch.tensor(0.0).to(device)
             lesson_reg = 0.0
             lesson_cls = 0.0
+            windows_trained = 0  # C-312: how many windows actually backpropagated
 
             # ADR-056: compute epsilon once per lesson
             ss_epsilon = ss_mixer.get_epsilon(lesson_idx) if ss_mixer is not None else 0.0
@@ -1012,9 +1013,35 @@ def training_loop(
                 losses = train(ctx, sample_handler, pbar, stage_label=slbl, ss_epsilon=ss_epsilon)
 
                 # --- MEMORY-SAFE ACCUMULATION (ADR 014 Hardening) ---
+                # C-312: this guard used to read `if w_loss > 0`, which is NOT the question
+                # ADR-014 means to ask. MultiTaskLoss adds `log(stds)`, negative once a task fits
+                # well (per task, the term is negative for `L < (r+1)/e`), so with the balancer
+                # unfrozen a perfectly healthy window scores below zero and the whole backward was
+                # skipped in silence — measured at 2 updates across 6 lessons. The question is
+                # "did this window have anything to learn from", i.e. is the loss exactly zero,
+                # which is what an all-masked / empty window produces. Under the production config
+                # (`freeze_multitask_balancer=True` pins log_vars at 0, so every term is >= 0)
+                # `!= 0` and `> 0` select identically — see
+                # tests/train/test_backward_gate.py
+                # ::test_the_new_guard_is_byte_identical_when_frozen.
                 w_loss = losses["total"]
-                if w_loss > 0 and not _bn_recal:  # BN-recal: forward-only, no grad
+                if not torch.isfinite(w_loss):
+                    raise ValueError(
+                        f"Lesson {lesson_idx + 1} window {window_idx + 1}: loss is "
+                        f"{w_loss.item()}, not a finite number. Refusing to backpropagate NaN/inf "
+                        "into the model — this is a bug upstream in the loss, not a skippable "
+                        "window."
+                    )
+                if _bn_recal:  # BN-recal: forward-only, no grad
+                    pass
+                elif w_loss.item() == 0.0:
+                    logger.debug(
+                        f"Lesson {lesson_idx + 1} window {window_idx + 1}: loss is exactly 0 "
+                        "(no supervised cells) — no backward, as ADR-014 intends."
+                    )
+                else:
                     w_loss.backward()
+                    windows_trained += 1
 
                 lesson_loss += w_loss.detach()  # Keep track of magnitude for logging
                 lesson_reg += losses["reg"].item()
@@ -1024,7 +1051,10 @@ def training_loop(
                 del sample_handler, losses, w_loss
 
             # --- THE OPTIMIZATION GATE (ADR 014) ---
-            if lesson_loss > 0:
+            # C-312: gated on whether gradient was actually produced, not on the SIGN of the
+            # accumulated loss. `or _bn_recal` preserves the pre-fix behaviour of the recal pass,
+            # which enters this block for its diagnostics but is separately barred from stepping.
+            if windows_trained > 0 or _bn_recal:
                 # NUMERICAL AUDIT: Hard stop on explosion
                 IntegrityGuardian.monitor(
                     model, torch.tensor([0.0]), lesson_loss, context=f"Lesson {lesson_idx}"
@@ -1076,9 +1106,15 @@ def training_loop(
                     _traj_acc["gate_sum"] = 0.0
                     _traj_acc["gate_n"] = 0
 
-                # Gradient Clipping
+                # Gradient Clipping. C-314: the threshold used to be the literal 1.0 while the
+                # only config field was the on/off bool, so it could not be tuned from a config at
+                # all. `clip_grad_max_norm` defaults to 1.0, so every existing config is unchanged.
+                # NOTE (still open, C-314): this covers `model.parameters()` only — the balancer's
+                # `log_vars` are a separate optimizer param group and are clipped by nothing.
                 if config.get("clip_grad_norm"):
-                    torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+                    torch.nn.utils.clip_grad_norm_(
+                        model.parameters(), max_norm=config.get("clip_grad_max_norm", 1.0)
+                    )
 
                 # Optimize (Update Weights) — skipped in BN-recal (weights frozen, BN only)
                 if not _bn_recal:

--- a/views_hydranet/train/training_engine.py
+++ b/views_hydranet/train/training_engine.py
@@ -278,6 +278,8 @@ def _process_sequence(
     ss_feedback: str = "mean",
     forecast_composition: str = "self_zeroed",
     gate_threshold: float | None = None,
+    pushforward_weight: float = 0.0,
+    pushforward_detach_state: bool = False,
 ) -> dict[str, Any]:
     """
     Pure sequence processing: forward pass over [B, T, C, H, W] tensor.
@@ -513,8 +515,54 @@ def _process_sequence(
             )
             losses_list.append(crit_cj(pred_cj, targ_cj))
 
+        # ── PUSHFORWARD (Brandstetter et al. 2022, #289) ────────────────────────────────────
+        # An AUXILIARY loss, not a change to the trajectory: the main loop above stays exactly
+        # teacher-forced, so `pushforward_weight == 0.0` is byte-identical to the pre-flag model.
+        #
+        # Take one extra step from the model's OWN emitted field and score it against ground truth
+        # at t+2 — "unroll 2 steps, cut the gradient after the first, compute the loss at the
+        # pushforward time". The gradient cut is `.detach()` on the fed field, which on the
+        # `sample` path is already unavoidable (`torch.poisson` severs it; measured as exactly 0.0),
+        # so on that path that half of the paper's method is a NO-OP and the SECOND UNROLL is the
+        # entire intervention. Recorded because implementing only the detach would have done
+        # nothing while looking correct.
+        #
+        # `pushforward_detach_state` is a fork the paper cannot settle: its solver is stateless, so
+        # cutting the input cuts every path. Ours is recurrent and `h` carries gradient, so False
+        # (default) lets the pushforward loss train the RECURRENCE to produce states that survive
+        # one step of self-feeding. True reproduces the stateless reading.
+        pf_loss = None
+        if pushforward_weight > 0.0 and family is not None and i + 2 < seq_len:
+            fed = _family_feedback_log1p(
+                t1_pred,
+                family,
+                ss_feedback,
+                torch.sigmoid(t1_pred_class),
+                forecast_composition,
+                gate_threshold,
+            ).detach()
+            pf_in = _attach_static_channels(fed, t0, idx)
+            pf_h = h.detach() if pushforward_detach_state else h
+            pf_out = model(pf_in, pf_h)
+            y2_reg = train_tensor[:, i + 2, idx.reg, :, :]
+            pf_terms = []
+            for j, name in enumerate(idx.reg_names):
+                loss_fn_j = (
+                    criterion_reg[name] if isinstance(criterion_reg, dict) else criterion_reg
+                )
+                npar = getattr(loss_fn_j, "n_params", 1)
+                pf_terms.append(
+                    loss_fn_j(
+                        pf_out.reg[:, j * npar : (j + 1) * npar].permute(0, 2, 3, 1),
+                        y2_reg[:, j],
+                    )
+                )
+            pf_loss = torch.stack(pf_terms).sum()
+
         losses = torch.stack(losses_list)
         loss = cast(Any, multitaskloss_instance)(losses)
+        if pf_loss is not None:
+            loss = loss + pushforward_weight * pf_loss
         if qs99_weight is not None and qs99_weight > 0:
             loss = loss + qs99_weight * qs99_loss
         if decay_gate_weight > 0:
@@ -690,6 +738,8 @@ def train(
         ss_feedback=config.get("ss_feedback", "mean"),
         forecast_composition=config.get("forecast_composition", "self_zeroed"),
         gate_threshold=config.get("gate_threshold"),
+        pushforward_weight=config.get("pushforward_weight", 0.0),
+        pushforward_detach_state=config.get("pushforward_detach_state", False),
     )
     step_total, step_reg, step_cls = result["per_step_losses"]
 

--- a/views_hydranet/train/training_engine.py
+++ b/views_hydranet/train/training_engine.py
@@ -11,6 +11,7 @@ All functions here are importable and testable without views_pipeline_core.
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import logging
 import math
@@ -155,6 +156,32 @@ class _SequenceIndices:
         self.n_cls = len(cls_targets)
         self.reg_names = reg_targets
         self.cls_names = cls_targets
+
+
+@contextlib.contextmanager
+def _batchnorm_eval(model: nn.Module):
+    """Run a forward without letting it touch BatchNorm running statistics.
+
+    ``model.eval()`` on the whole model would also disable dropout and change the forward; this
+    flips only the ``_BatchNorm`` modules that are currently training, and restores exactly those.
+    ``torch.no_grad()`` is NOT a substitute — it stops gradients, not buffer updates.
+
+    Used by the pushforward auxiliary step (#289), whose extra forward would otherwise write
+    self-fed, off-distribution activations into buffers that are saved with the artifact and
+    recomputed by the C-184 BN recalibration.
+    """
+    flipped = [
+        m
+        for m in model.modules()
+        if isinstance(m, torch.nn.modules.batchnorm._BatchNorm) and m.training
+    ]
+    for m in flipped:
+        m.eval()
+    try:
+        yield
+    finally:
+        for m in flipped:
+            m.train()
 
 
 def _attach_static_channels(
@@ -516,8 +543,30 @@ def _process_sequence(
             losses_list.append(crit_cj(pred_cj, targ_cj))
 
         # ── PUSHFORWARD (Brandstetter et al. 2022, #289) ────────────────────────────────────
-        # An AUXILIARY loss, not a change to the trajectory: the main loop above stays exactly
-        # teacher-forced, so `pushforward_weight == 0.0` is byte-identical to the pre-flag model.
+        # An AUXILIARY loss. It does not change the recurrent trajectory — `h` is threaded by the
+        # main teacher-forced loop only — and at `pushforward_weight == 0.0` the branch is never
+        # entered, so that setting is byte-identical to the pre-flag model.
+        #
+        # It is NOT side-effect-free, and two side effects have to be suppressed explicitly:
+        #
+        # 1. **BatchNorm.** The model is in `train()` mode, so an extra `model(...)` call updates
+        #    `running_mean`/`running_var`/`num_batches_tracked` on all 15 BN layers — measured at
+        #    `num_batches_tracked` 5 -> 9 on a T=6 window, i.e. roughly HALF the saved BN
+        #    statistics would come from self-fed, off-distribution inputs. Those buffers are model
+        #    state: they go into the artifact and are used at eval. Worse, `train()` is also the
+        #    workhorse of `_recalibrate_bn` (the C-184 fix, `bn_recalibrate: True` by default),
+        #    which resets BN and recomputes with `momentum=None` — a cumulative average, so the
+        #    pushforward forwards would carry EQUAL weight rather than an EMA discount. An arm with
+        #    `pushforward_weight > 0` would then differ from its control at the BN layer for
+        #    reasons unrelated to the auxiliary loss, confounding the A/B. Suppressed by running
+        #    the extra forward with BN in eval mode.
+        # 2. **The recalibration pass itself.** `_recalibrate_bn` calls this under `no_grad`, where
+        #    the pushforward loss is computed and discarded — pure cost. Skipped via
+        #    `torch.is_grad_enabled()`.
+        #
+        # Dropout still advances the global RNG stream on the extra forward. Harmless (it cannot
+        # reach the `pushforward_weight == 0.0` control, which never enters this branch), but two
+        # arms differing only in `pushforward_weight` do not share a dropout stream.
         #
         # Take one extra step from the model's OWN emitted field and score it against ground truth
         # at t+2 — "unroll 2 steps, cut the gradient after the first, compute the loss at the
@@ -533,7 +582,12 @@ def _process_sequence(
         # (default) lets the pushforward loss train the RECURRENCE to produce states that survive
         # one step of self-feeding. True reproduces the stateless reading.
         pf_loss = None
-        if pushforward_weight > 0.0 and family is not None and i + 2 < seq_len:
+        if (
+            pushforward_weight > 0.0
+            and family is not None
+            and i + 2 < seq_len
+            and torch.is_grad_enabled()  # see (2) above: no-op under _recalibrate_bn's no_grad
+        ):
             fed = _family_feedback_log1p(
                 t1_pred,
                 family,
@@ -542,18 +596,30 @@ def _process_sequence(
                 forecast_composition,
                 gate_threshold,
             ).detach()
-            pf_in = _attach_static_channels(fed, t0, idx)
+            # The fed field stands in for t+1, so its static channels come from t1, matching how
+            # the main path pairs `dyn_input` with its own `t0`. A no-op while statics are
+            # geometry-constant, but the inconsistent pairing would become a real bug the moment a
+            # time-varying "static" channel is added.
+            pf_in = _attach_static_channels(fed, t1, idx)
             pf_h = h.detach() if pushforward_detach_state else h
-            pf_out = model(pf_in, pf_h)
+            with _batchnorm_eval(model):  # see (1) above
+                pf_out = model(pf_in, pf_h)
             y2_reg = train_tensor[:, i + 2, idx.reg, :, :]
             pf_terms = []
             for j, name in enumerate(idx.reg_names):
                 loss_fn_j = (
                     criterion_reg[name] if isinstance(criterion_reg, dict) else criterion_reg
                 )
-                npar = getattr(loss_fn_j, "n_params", 1)
+                # `family is not None` guarantees FamilyLoss, which always exposes n_params.
+                # Indexed rather than getattr-with-default: a default of 1 would silently
+                # mis-slice a multi-channel head instead of failing.
+                npar = loss_fn_j.n_params
+                # C-87 parity with the main reg loop: the same per-target weight, or the auxiliary
+                # term silently re-weights the targets relative to the primary objective.
+                tw_pf = 1.0 if target_weights is None else target_weights[name]
                 pf_terms.append(
-                    loss_fn_j(
+                    tw_pf
+                    * loss_fn_j(
                         pf_out.reg[:, j * npar : (j + 1) * npar].permute(0, 2, 3, 1),
                         y2_reg[:, j],
                     )
@@ -967,9 +1033,19 @@ def training_loop(
         )
         logger.info(f"📈 trajectory-log ON → {_traj_path}")
 
-    with tqdm(
-        total=total_iterations, desc="👾 Training HydraNet", unit="month", leave=True
-    ) as pbar:
+    # The optional trajectory CSV must close on ANY exit from the lesson loop, not just the happy
+    # one. `IntegrityGuardian.monitor` has always been able to raise from inside this loop, and the
+    # C-312 non-finite check adds a second such exit; neither reached the `close()` below.
+    _traj_cleanup = contextlib.ExitStack()
+    if _traj_file is not None:
+        _traj_cleanup.callback(_traj_file.close)
+
+    with (
+        _traj_cleanup,
+        tqdm(
+            total=total_iterations, desc="👾 Training HydraNet", unit="month", leave=True
+        ) as pbar,
+    ):
         # Loop over Strategic Lessons
         for lesson_idx in range(config["total_lessons"]):
             optimizer.zero_grad()  # Reset gradients at start of Lesson
@@ -1021,23 +1097,37 @@ def training_loop(
                 # "did this window have anything to learn from", i.e. is the loss exactly zero,
                 # which is what an all-masked / empty window produces. Under the production config
                 # (`freeze_multitask_balancer=True` pins log_vars at 0, so every term is >= 0)
-                # `!= 0` and `> 0` select identically — see
+                # `!= 0` and `> 0` select identically. NOTE "every term is >= 0" holds in float32,
+                # where mtloss's `log(stds + eps)` = `log(1 + 1e-8)` rounds to exactly 0.0; in
+                # float64 it is +1e-8 per task, still >= 0, so the equivalence survives either way.
+                # The test does not re-derive this — it observes every window's actual total. See
                 # tests/train/test_backward_gate.py
                 # ::test_the_new_guard_is_byte_identical_when_frozen.
                 w_loss = losses["total"]
-                if not torch.isfinite(w_loss):
-                    raise ValueError(
+                if _bn_recal:
+                    # BN-recal is forward-only: no backward, and no reason to abort the pass over
+                    # a non-finite loss nobody consumes. Kept OUT of the finiteness check below so
+                    # a `bn_recal_from` run behaves exactly as it did before this fix.
+                    pass
+                elif not torch.isfinite(w_loss):
+                    # RuntimeError, not ValueError: IntegrityGuardian.monitor raises RuntimeError
+                    # on the same condition a few lines below, and one fail-loud channel is worth
+                    # more than a more precise exception type nobody catches.
+                    raise RuntimeError(
                         f"Lesson {lesson_idx + 1} window {window_idx + 1}: loss is "
                         f"{w_loss.item()}, not a finite number. Refusing to backpropagate NaN/inf "
-                        "into the model — this is a bug upstream in the loss, not a skippable "
-                        "window."
+                        "into the model — this is a bug upstream in the loss (cf. C-212), not a "
+                        "skippable window. The old `if w_loss > 0` guard swallowed it silently."
                     )
-                if _bn_recal:  # BN-recal: forward-only, no grad
-                    pass
                 elif w_loss.item() == 0.0:
+                    # Reachable only when EVERY term is exactly zero. Under the production config
+                    # the classification terms are scored on the full grid with no mask, so an
+                    # all-zero target still yields a small non-zero BCE and this branch does not
+                    # fire — i.e. in production every window backpropagates, which is the intent.
+                    # It stays because a masked / genuinely empty window must not cost a backward.
                     logger.debug(
                         f"Lesson {lesson_idx + 1} window {window_idx + 1}: loss is exactly 0 "
-                        "(no supervised cells) — no backward, as ADR-014 intends."
+                        "(nothing supervised) — no backward, as ADR-014 intends."
                     )
                 else:
                     w_loss.backward()
@@ -1161,8 +1251,7 @@ def training_loop(
 
     logger.info("✅ Training complete!")
 
-    if _traj_file is not None:
-        _traj_file.close()
+    # (the trajectory CSV is closed by _traj_cleanup on every exit path, including exceptions)
 
     # C-184 FIX: post-training BN recalibration (default ON). Mutates `model` in place so the saved
     # artifact has corrected BN running stats (fixes the seed-bimodal eval collapse). Skipped for a

--- a/views_hydranet/train/training_engine.py
+++ b/views_hydranet/train/training_engine.py
@@ -522,7 +522,8 @@ def _process_sequence(
         # Take one extra step from the model's OWN emitted field and score it against ground truth
         # at t+2 — "unroll 2 steps, cut the gradient after the first, compute the loss at the
         # pushforward time". The gradient cut is `.detach()` on the fed field, which on the
-        # `sample` path is already unavoidable (`torch.poisson` severs it; measured as exactly 0.0),
+        # `sample` path is already unavoidable (`torch.poisson` severs it; measured as
+        # exactly 0.0),
         # so on that path that half of the paper's method is a NO-OP and the SECOND UNROLL is the
         # entire intervention. Recorded because implementing only the detach would have done
         # nothing while looking correct.

--- a/views_hydranet/utils/config_initializer.py
+++ b/views_hydranet/utils/config_initializer.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from views_hydranet.distributions import resolve_family
+
 logger = logging.getLogger(__name__)
 
 
@@ -715,8 +717,10 @@ class HydraNetConfig(BaseModel):
 
     @model_validator(mode="after")
     def reject_unwired_rollout_horizon(self) -> "HydraNetConfig":
-        """C-264: `rollout_horizon` has NO runtime consumer yet — the ADR-058 B1 pushforward
-        path is unwired, so `training_loop`/`_process_sequence` always take the one-step path.
+        """C-264: `rollout_horizon` has NO runtime consumer yet — the ADR-058 B1 multi-step
+        rollout-training path is unwired, so `training_loop`/`_process_sequence` always take the
+        one-step path. (Distinct from `pushforward_weight` (#289), which IS wired: that is a
+        TWO-step auxiliary loss on a teacher-forced trajectory, not a K-step rollout.)
         A K>1 config would therefore SILENTLY train one-step (the experiment's premise invalid).
         Fail loud until the consumer lands (mirrors the other reject-if-ignored guards)."""
         if self.rollout_horizon != 1:
@@ -724,6 +728,24 @@ class HydraNetConfig(BaseModel):
                 f"rollout_horizon={self.rollout_horizon} but the multi-step rollout-training "
                 "path (ADR-058 B1) is NOT wired — nothing reads this knob, so K>1 would "
                 "silently run one-step training. Set rollout_horizon=1 until it lands (C-264)."
+            )
+            logger.error(err_msg)
+            raise ValueError(err_msg)
+        return self
+
+    @model_validator(mode="after")
+    def reject_pushforward_without_a_family(self) -> "HydraNetConfig":
+        """The #289 pushforward term is only computed when the head resolves to a distribution
+        family — `_process_sequence` guards on `family is not None`. A legacy / point / quantile
+        head with `pushforward_weight > 0` would therefore train with NO pushforward at all and
+        report a clean run, leaving the experiment's premise silently invalid. Mirrors
+        `reject_unwired_rollout_horizon`, which exists for exactly this failure mode."""
+        if self.pushforward_weight > 0.0 and resolve_family(self.output_distribution) is None:
+            err_msg = (
+                f"pushforward_weight={self.pushforward_weight} but output_distribution="
+                f"'{self.output_distribution}' does not resolve to a distribution family, so the "
+                "pushforward term is never computed — the run would look clean and train nothing "
+                "extra. Use a family head (e.g. 'nb'), or set pushforward_weight=0.0 (#289)."
             )
             logger.error(err_msg)
             raise ValueError(err_msg)

--- a/views_hydranet/utils/config_initializer.py
+++ b/views_hydranet/utils/config_initializer.py
@@ -102,6 +102,17 @@ class HydraNetConfig(BaseModel):
     scheduler: str = Field(...)
     warmup_steps: int = Field(..., ge=1)
     clip_grad_norm: bool = Field(...)
+    clip_grad_max_norm: float = Field(
+        default=1.0,
+        gt=0.0,
+        description=(
+            "C-314: the max_norm passed to clip_grad_norm_ when clip_grad_norm is True. "
+            "Was a literal 1.0 in training_engine, so the threshold could not be tuned from a "
+            "config at all; 1.0 is the default so every pre-existing config is unchanged. "
+            "Covers model.parameters() only — the MultiTaskLoss log_vars are a separate optimizer "
+            "param group and remain unclipped (C-314, open)."
+        ),
+    )
 
     # 6. Loss Functions (names: mse, shrinkage, lognormal_nll, tobit)
     loss_reg: str = Field(...)

--- a/views_hydranet/utils/config_initializer.py
+++ b/views_hydranet/utils/config_initializer.py
@@ -184,6 +184,16 @@ class HydraNetConfig(BaseModel):
     # progressively more ground truth. An ITF arm sets ss_warmup_lessons to the TOTAL lesson count,
     # because that is the linear ramp length — see the itf-pilot dossier's AMENDMENT 1.
     ss_reverse: bool = Field(default=False)
+    # #289 (Brandstetter et al. 2022): pushforward. An AUXILIARY loss — one extra unrolled step
+    # from the model's own emitted field, scored against ground truth at t+2. 0.0 (default) is
+    # byte-identical to the pre-flag model: the term is never computed. The main training loop
+    # stays teacher-forced either way; this does not change the trajectory, only the objective.
+    pushforward_weight: float = Field(default=0.0, ge=0.0)
+    # The paper's solver is stateless, so cutting the fed-back input cuts every gradient path.
+    # Ours is recurrent: `h` carries gradient, so False (default) lets the pushforward loss train
+    # the RECURRENCE to produce states that survive one step of self-feeding. True reproduces the
+    # stateless reading. Recorded as a fork the paper cannot settle for a recurrent model.
+    pushforward_detach_state: bool = Field(default=False)
 
     # 7. Sampling & Reproducibility
     total_lessons: int = Field(..., ge=1)


### PR DESCRIPTION
Three things, in the order they happened: the #289 pushforward implementation, the training-loop audit that was supposed to *gate* it, and the fixes that audit found. They ship together because the audit found a critical bug **in the pushforward itself**.

No experiment has been run. `pushforward_weight` defaults to `0.0` and that path is byte-identical to before.

## 1. The audit — is the backward path actually correct?

Verified rather than assumed: all 79 parameter groups receive finite non-zero gradient, the reg loss reaches both `mu` and `theta`, the gate loss reaches the gate head. **No past result is invalidated.**

Four things had no behavioural coverage at all:

- **`clip_grad_norm_`** — deleting the call passed all 1630 tests. `max_norm=1.0` was a literal while the config field is a *bool*.
- **Per-parameter gradient** — the two closest tests use `any()`, so a dead head was invisible.
- **The untruncated BPTT graph** — `h` is rebound un-detached and the whole ~383-step sequence is one `backward()`. Nothing pinned it; nothing measured whether the reach is used.
- **The `if w_loss > 0` gate.**

### Two measurements that correct priors

**BPTT reach is real.** `d‖h_final‖²/dx_i` at 118 steps back:

| | random init | trained L=300 |
|---|---|---|
| 20 steps back | 1.4e-03 | 3.94e+00 |
| 118 steps back | **2.8e-17** | **1.6e-02** |

Random init is sharply contractive and geometric (MillerHardt's stable regime); training escapes it and the decay becomes sub-exponential. So the full graph earns its memory — and **M46's `WideMemory` null is not a vanishing-gradient story.**

**The balancer can switch training off.** `MultiTaskLoss` adds `log(stds)`, negative once a task fits well (`L < (r+1)/e` — exactly where descent on `log_vars` is heading). Both ADR-014 guards keyed on that sign. Measured: **2 optimizer updates across 6 lessons**, nothing logged above DEBUG — the progress bar advances, wandb receives rows, the run looks healthy. Production was never exposed (every live arm pins `freeze_multitask_balancer: True`), but the config **default is `False`**.

## 2. The critical bug — found by review, in the pushforward

The extra forward runs in `train()` mode, so it **updated BatchNorm running statistics**: `num_batches_tracked` 5 → 9 on a T=6 window, `bn_enc_conv0.running_mean` moved 0.054. Roughly half the saved BN statistics would have come from self-fed, off-distribution inputs.

Those buffers go into the artifact and are used at eval — and the **C-184 recalibration** (`bn_recalibrate: True` by default) recomputes them with `momentum=None`, a cumulative average, so the pushforward forwards would have carried **equal weight**. An arm with `pushforward_weight > 0` would have differed from its control **at the BN layer**, for reasons having nothing to do with the auxiliary loss. The A/B would have been confounded and the experiment would have looked clean.

`torch.no_grad()` is not a defence — it stops gradients, not buffer updates.

Fixed with `_batchnorm_eval()`, plus the term is now skipped entirely under `no_grad` (pure cost during recalibration).

## 3. What changed in production code

| | |
|---|---|
| **C-312 FIXED** | The guards now ask ADR-014's question — *did this window have data?* A window backpropagates unless its loss is exactly zero; a **non-finite** loss now **raises** instead of being silently skipped (C-212 was exactly such a bug); the optimization gate keys on `windows_trained > 0`. After: **6 of 6** lessons update. |
| **C-314 part-fixed** | `clip_grad_max_norm` config field, default 1.0. **(3) stays open**: the clip still covers `model.parameters()` only, so the balancer's `log_vars` — an unbounded amplifier — are unclipped. Fixing that moves training dynamics whenever the balancer is active, so it is the owner's call, not an audit side effect. |
| **C-303, tenth occurrence** | `HydraBNrecurrentUnet_06_LSTM4.py:104` claimed softplus *"cannot die"*. True of the activation, false of the path — `nb_core._clamp` kills the gradient at `raw ≤ -13.8155`. First instance in production source rather than a report. |
| **New validator** | `pushforward_weight > 0` on a non-family head was a silent no-op. Mirrors `reject_unwired_rollout_horizon`, which exists for that exact failure. |

**C-112 answered by measurement, not assertion.** Under the frozen balancer the old (`> 0`) and new (`!= 0`) predicates provably select the same windows — `test_the_new_guard_is_byte_identical_when_frozen` observes every window's total during a real run rather than re-deriving the algebra. **No existing result moves.**

## Registered and NOT fixed, deliberately

- **C-313** — the NB clamp reinstates C-178's dead-gradient trap at `raw ≤ -13.8155` (gradient → exactly 0.0, irrecoverable). **Latent and remote**: at the incumbent's operating point the mu gradient is −0.207 and its *sign pushes away* from the cliff (~48k steps in the wrong direction). Dedup found C-202 covers the same clamp but examined **θ only**, where the softplus cancellation works; `mu` was never in scope. C-202 is *incomplete*, not wrong.
- **C-315** — the untruncated graph. Justified by the reach measurement above.
- **C-316** — `test_reproducibility_gate` deleted `training_engine` from `sys.modules` to grep its source and never restored it, so every later monkeypatch of it silently patched an object nothing called. Fixed and guarded.

## Verification

**20/20 mutations caught**, applied to production code, guard run, reverted, tree confirmed clean. Five survived first and forced real rewrites:

| survivor | why it survived | fix |
|---|---|---|
| delete the backward guard | a *second* guard masked it — counting `optimizer.step` can't see it | count backward passes via a post-accumulate-grad hook |
| re-add the `sys.modules` delete | hardening the victims removed the only signal the bug existed | assert the invariant directly |
| revert t1→t0 statics | the "did it move?" test moves under either reading | recompute both references |
| drop `target_weights` | no test set them | assert on the pushforward *contribution* |
| delete the new validator | no test | three tests beside the precedent's |

1825 tests pass, `ruff check` and `ruff format --check` clean.

**Cost, measured on production shapes** (`window_dim=32`, `T=336`): pushforward is **+58% memory, ×1.76 wall-clock** ⇒ ~3.2 h/arm. `pushforward_detach_state` is free either way.

Refs #289. Register: C-303 (10th), C-312, C-313, C-314, C-315, C-316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
